### PR TITLE
4dsound nap pr january 2020

### DIFF
--- a/modules/napapp/src/apprunner.h
+++ b/modules/napapp/src/apprunner.h
@@ -176,7 +176,6 @@ namespace nap
 		if(!error.check(app.init(error), "unable to initialize application"))
 		{
 			mCore.shutdownServices();
-			error.fail("Failed to initialize application");
 			return false;
 		}
 

--- a/modules/napapp/src/apprunner.h
+++ b/modules/napapp/src/apprunner.h
@@ -174,7 +174,11 @@ namespace nap
 
 		// Initialize application
 		if(!error.check(app.init(error), "unable to initialize application"))
+		{
+			mCore.shutdownServices();
+			error.fail("Failed to initialize application");
 			return false;
+		}
 
 		// Start event handler
 		app_event_handler.start();

--- a/modules/napaudio/src/audio/core/audiopin.cpp
+++ b/modules/napaudio/src/audio/core/audiopin.cpp
@@ -116,7 +116,6 @@ namespace nap
 		
 		MultiInputPin::MultiInputPin(Node* node, unsigned int reservedInputCount) : InputPinBase(node)
 		{
-			mPullResult.reserve(reservedInputCount);
 			mInputsCache.reserve(reservedInputCount);
 		}
 		
@@ -127,16 +126,14 @@ namespace nap
 		}
 		
 		
-		std::vector<SampleBuffer*>& MultiInputPin::pull()
+		void MultiInputPin::pull(std::vector<SampleBuffer*>& result)
 		{
 			// Make a copy of mInputs because its contents can change while pulling its content.
 			mInputsCache = mInputs;
 			
-			mPullResult.clear();
-			for (auto& input : mInputsCache)
-				mPullResult.emplace_back(input->pull());
-			
-			return mPullResult;
+			result.resize(mInputsCache.size());
+			for (auto i = 0; i < mInputsCache.size(); ++i)
+				result[i] = mInputsCache[i]->pull();
 		}
 		
 		
@@ -168,16 +165,13 @@ namespace nap
 				assert(it != mInputs.end());
 				mInputs.erase(it);
 			}
-			mPullResult.clear();
 			mInputsCache.clear();
 		}
 		
 		
 		void MultiInputPin::reserveInputs(unsigned int inputCount)
 		{
-			mPullResult.shrink_to_fit();
 			mInputsCache.shrink_to_fit();
-			mPullResult.reserve(inputCount);
 			mInputsCache.reserve(inputCount);
 		}
 		

--- a/modules/napaudio/src/audio/core/audiopin.h
+++ b/modules/napaudio/src/audio/core/audiopin.h
@@ -153,9 +153,9 @@ namespace nap
 			
 			/**
 			 * This method can be used by the node to pull a buffer of samples for every connected output pin.
-			 * @return: the vector can contain nullptr items if somewhere down the line of connection silence is returned.
+			 * @param result the vector will be resized and filled with a SampleBuffer* for each connected pin. The vector can contain nullptr items if somewhere down the line of connection silence is returned. It is advised to allocate the result vector in the constructor of the Node class that contains the MultiInpuPin, and to preallocate memory using vector<>::reserve(), in order to avoid allocations on the audio thread.
 			 */
-			std::vector<SampleBuffer*>& pull();
+			void pull(std::vector<SampleBuffer*>& result);
 			
 			/**
 			 * Connect another node's output to this pin.
@@ -187,7 +187,6 @@ namespace nap
 		
 		private:
 			std::vector<OutputPin*> mInputs;
-			std::vector<SampleBuffer*> mPullResult;
 			std::vector<OutputPin*> mInputsCache;
 		};
 		

--- a/modules/napaudio/src/audio/core/audiopin.h
+++ b/modules/napaudio/src/audio/core/audiopin.h
@@ -156,7 +156,7 @@ namespace nap
 			 * A result verctor has to be passed as an argument.
 			 * The vector will be resized and filled with a SampleBuffer* for each connected pin.
 			 * The contents of the vector can be nullptr when somewhere down the conected graph an output returns nullptr.
-			 * It is advised to allocate the result vector in the constructor of the Node class that contains the MultiInpuPin, and to preallocate memory using vector<>::reserve(), in order to avoid allocations on the audio thread.
+			 * It is advised to allocate the result vector in the constructor of the Node class that contains the MultiInpuPin, and to prea	llocate memory using vector<>::reserve(), in order to avoid allocations on the audio thread.
 			 * @param result vector that will be filled with pointers to a buffer for each connection.
 			 */
 			void pull(std::vector<SampleBuffer*>& result);

--- a/modules/napaudio/src/audio/core/audiopin.h
+++ b/modules/napaudio/src/audio/core/audiopin.h
@@ -153,7 +153,11 @@ namespace nap
 			
 			/**
 			 * This method can be used by the node to pull a buffer of samples for every connected output pin.
-			 * @param result the vector will be resized and filled with a SampleBuffer* for each connected pin. The vector can contain nullptr items if somewhere down the line of connection silence is returned. It is advised to allocate the result vector in the constructor of the Node class that contains the MultiInpuPin, and to preallocate memory using vector<>::reserve(), in order to avoid allocations on the audio thread.
+			 * A result verctor has to be passed as an argument.
+			 * The vector will be resized and filled with a SampleBuffer* for each connected pin.
+			 * The contents of the vector can be nullptr when somewhere down the conected graph an output returns nullptr.
+			 * It is advised to allocate the result vector in the constructor of the Node class that contains the MultiInpuPin, and to preallocate memory using vector<>::reserve(), in order to avoid allocations on the audio thread.
+			 * @param result vector that will be filled with pointers to a buffer for each connection.
 			 */
 			void pull(std::vector<SampleBuffer*>& result);
 			

--- a/modules/napaudio/src/audio/node/mixnode.cpp
+++ b/modules/napaudio/src/audio/node/mixnode.cpp
@@ -13,21 +13,27 @@ namespace nap
 {
 	namespace audio
 	{
+
+		MixNode::MixNode(NodeManager& manager, int reservedInputCount) : Node(manager), inputs(this, reservedInputCount)
+		{
+			mInputBuffers.reserve(reservedInputCount);
+		}
+
 		
 		void MixNode::process()
 		{
 			auto& outputBuffer = getOutputBuffer(audioOutput);
-			auto& inputBuffers = inputs.pull();
+			inputs.pull(mInputBuffers);
 			
 			for (auto i = 0; i < outputBuffer.size(); ++i)
 				outputBuffer[i] = 0;
 			
-			for (auto& inputBuffer : inputBuffers)
+			for (auto& inputBuffer : mInputBuffers)
 				if (inputBuffer)
 					for (auto i = 0; i < outputBuffer.size(); ++i)
 						outputBuffer[i] += (*inputBuffer)[i];
 		}
-		
+
 	}
 }
 

--- a/modules/napaudio/src/audio/node/mixnode.h
+++ b/modules/napaudio/src/audio/node/mixnode.h
@@ -19,12 +19,17 @@ namespace nap
 			RTTI_ENABLE(Node)
 		
 		public:
-			MixNode(NodeManager& manager) : Node(manager) { }
+			/**
+			 * Constructor
+			 * @param manager the node manager this node will be processed by
+			 * @param reservedInputCount the number of input pointers that will be pre allocated to hold the result value.
+			 */
+			MixNode(NodeManager& manager, int reservedInputCount = 2);
 			
 			/**
 			 * The input to be mixed
 			 */
-			MultiInputPin inputs = {this};
+			MultiInputPin inputs;
 			
 			/**
 			 * Outputs the mixed signal
@@ -36,6 +41,8 @@ namespace nap
 			 * Calculate the output, perform the scaling
 			 */
 			void process() override;
+
+			std::vector<SampleBuffer*> mInputBuffers; // Internal preallocated input result buffer
 		};
 		
 	}

--- a/modules/napaudio/src/audio/node/multiplynode.cpp
+++ b/modules/napaudio/src/audio/node/multiplynode.cpp
@@ -8,14 +8,20 @@ namespace nap
 {
 	namespace audio
 	{
+
+		MultiplyNode::MultiplyNode(NodeManager& nodeManager, int reservedInputCount) : Node(nodeManager), inputs(this, reservedInputCount)
+		{
+			mInputBuffers.reserve(reservedInputCount);
+		}
+
 		
 		void MultiplyNode::process()
 		{
 			auto& outputBuffer = getOutputBuffer(audioOutput);
-			auto& inputBuffers = inputs.pull();
+			inputs.pull(mInputBuffers);
 			
 			// In case no inputs are connected, return zeros
-			if (inputBuffers.empty()) {
+			if (mInputBuffers.empty()) {
 				for (auto i = 0; i < outputBuffer.size(); ++i)
 					outputBuffer[i] = 0;
 				return;
@@ -23,17 +29,17 @@ namespace nap
 			
 			// Copy the first input to the output
 			auto inputIndex = 0;
-			auto inputBuffer = *inputBuffers.begin();
+			auto inputBuffer = *mInputBuffers.begin();
 			for (auto i = 0; i < outputBuffer.size(); ++i)
 				outputBuffer[i] = (*inputBuffer)[i];
 			
 			// Multiply the output with the consecutive inputs from the second onwards
-			for (inputIndex = 1; inputIndex < inputBuffers.size(); ++inputIndex) {
-				inputBuffer = inputBuffers[inputIndex];
+			for (inputIndex = 1; inputIndex < mInputBuffers.size(); ++inputIndex) {
+				inputBuffer = mInputBuffers[inputIndex];
 				for (auto i = 0; i < outputBuffer.size(); ++i)
 					outputBuffer[i] *= (*inputBuffer)[i];
 			}
 		}
-		
+
 	}
 }

--- a/modules/napaudio/src/audio/node/multiplynode.h
+++ b/modules/napaudio/src/audio/node/multiplynode.h
@@ -17,12 +17,17 @@ namespace nap
 		class NAPAPI MultiplyNode : public Node
 		{
 		public:
-			MultiplyNode(NodeManager& nodeManager) : Node(nodeManager) { }
+			/**
+			 * Constructor
+			 * @param manager the node manager this node will be processed by
+			 * @param reservedInputCount the number of input pointers that will be pre allocated to hold the result value.
+			 */
+			MultiplyNode(NodeManager& nodeManager, int reservedInputCount = 2);
 			
 			/**
 			 * All signals connected to this pin will be multiplied.
 			 */
-			MultiInputPin inputs = {this};
+			MultiInputPin inputs;
 			
 			/**
 			 * Outputs the signal containing a the multiplication result of all inputs.
@@ -34,6 +39,8 @@ namespace nap
 			 * Calculate the output, perform the multiplication
 			 */
 			void process() override;
+
+			std::vector<SampleBuffer*> mInputBuffers; // Internal preallocated input result buffer
 		};
 		
 	}

--- a/modules/napaudio/src/audio/service/audioservice.h
+++ b/modules/napaudio/src/audio/service/audioservice.h
@@ -237,8 +237,7 @@ namespace nap
 			 * Tries to open the audio stream using the given settings.
 			 * @return true on success.
 			 */
-			bool openStream(int inputDeviceIndex, int outputDeviceIndex, int inputChannelCount, int outputChannelCount,
-			                float sampleRate, int bufferSize, int internalBufferSize, utility::ErrorState& errorState);
+			bool openStream(int hostApi, int inputDeviceIndex, int outputDeviceIndex, int inputChannelCount, int outputChannelCount, float sampleRate, int bufferSize, int internalBufferSize, utility::ErrorState& errorState);
 			
 			/**
 			 * Closes the current stream. Assumes that it has been opened successfully.

--- a/modules/napaudio/src/audio/utility/safeptr.cpp
+++ b/modules/napaudio/src/audio/utility/safeptr.cpp
@@ -12,31 +12,10 @@ namespace nap
 		
 		DeletionQueue::~DeletionQueue()
 		{
-			enqueueAll();
 			clear();
 		}
 		
-		
-		void DeletionQueue::registerSafeOwner(SafeOwnerBase* ptr)
-		{
-			mSafeOwnerList.emplace(ptr);
-		}
-		
-		
-		void DeletionQueue::unregisterSafeOwner(SafeOwnerBase* ptr)
-		{
-			mSafeOwnerList.erase(ptr);
-		}
-		
-		
-		void DeletionQueue::enqueueAll()
-		{
-			auto tempSafeOwnerList = mSafeOwnerList; // make a copy because enqueueForDeletion() will remove items from mSafeOwnerList.
-			for (auto ptr : tempSafeOwnerList)
-				ptr->enqueueForDeletion();
-		}
-		
-		
+
 		void DeletionQueue::clear()
 		{
 			std::unique_ptr<SafeOwnerBase::Data> toBeDeleted = nullptr;
@@ -58,14 +37,9 @@ namespace nap
 			// Then we copy the source data
 			setData(std::move(source.getData()));
 
-//            // Because we transfer ownership here we set the source's data pointer to nullptr.
-//            source.mData = nullptr;
-			
 			auto newDeletionQueue = source.getDeletionQueue();
-			newDeletionQueue->unregisterSafeOwner(&source); // unregister the previous source ptr
 			source.setDeletionQueue(nullptr);  // empty the deletion queue value in the source ptr
 			setDeletionQueue(newDeletionQueue);// set the deletion queue of this ptr
-			newDeletionQueue->registerSafeOwner(this);       // register this ptr with the new deletion queue
 		}
 		
 	}

--- a/modules/napparameter/src/parameternumeric.h
+++ b/modules/napparameter/src/parameternumeric.h
@@ -109,5 +109,7 @@ namespace nap
 			RTTI_PROPERTY("Value",		&Type::mValue,			nap::rtti::EPropertyMetaData::Default)				\
 			RTTI_PROPERTY("Minimum",	&Type::mMinimum,		nap::rtti::EPropertyMetaData::Default)				\
 			RTTI_PROPERTY("Maximum",	&Type::mMaximum,		nap::rtti::EPropertyMetaData::Default)				\
+			RTTI_FUNCTION("setValue",	static_cast<void (Type::*)(decltype(Type::mValue))>(&Type::setValue))	\
 		RTTI_END_CLASS
+
 }

--- a/modules/napparameter/src/parametersimple.h
+++ b/modules/napparameter/src/parametersimple.h
@@ -88,4 +88,5 @@ namespace nap
 #define DEFINE_SIMPLE_PARAMETER(Type)																			\
 	RTTI_BEGIN_CLASS(Type)																						\
 		RTTI_PROPERTY("Value",		&Type::mValue,		nap::rtti::EPropertyMetaData::Default)					\
+		RTTI_FUNCTION("setValue",	static_cast<void (Type::*)(const decltype(Type::mValue)&)>(&Type::setValue))\
 	RTTI_END_CLASS

--- a/modules/napparameter/src/parametervec.h
+++ b/modules/napparameter/src/parametervec.h
@@ -116,5 +116,6 @@ namespace nap
 			RTTI_PROPERTY("Clamp",		&Type::mClamp,			nap::rtti::EPropertyMetaData::Default)				\
 			RTTI_PROPERTY("Minimum",	&Type::mMinimum,		nap::rtti::EPropertyMetaData::Default)				\
 			RTTI_PROPERTY("Maximum",	&Type::mMaximum,		nap::rtti::EPropertyMetaData::Default)				\
+			RTTI_FUNCTION("setValue",	static_cast<void (Type::*)(decltype(Type::mValue))>(&Type::setValue))	\
 		RTTI_END_CLASS
 }

--- a/utility/src/utility/threading.cpp
+++ b/utility/src/utility/threading.cpp
@@ -38,6 +38,12 @@ namespace nap
             count = mQueue.try_dequeue_bulk(it, mDequeuedTasks.size());
         }
     }
+
+
+	WorkerThread::WorkerThread() : mBlocking(true), mTaskQueue(20)
+	{
+		mRunning = false;
+	}
     
     
     WorkerThread::WorkerThread(bool blocking, int maxQueueItems) : mBlocking(blocking), mTaskQueue(maxQueueItems)

--- a/utility/src/utility/threading.cpp
+++ b/utility/src/utility/threading.cpp
@@ -11,7 +11,7 @@
 namespace nap
 {
     
-    TaskQueue::TaskQueue(unsigned int maxQueueItems) : mQueue(maxQueueItems)
+    TaskQueue::TaskQueue(int maxQueueItems) : mQueue(maxQueueItems)
     {
         mDequeuedTasks.resize(maxQueueItems);
     }
@@ -40,7 +40,7 @@ namespace nap
     }
     
     
-    WorkerThread::WorkerThread(bool blocking, unsigned int maxQueueItems) : mBlocking(blocking), mTaskQueue(maxQueueItems)
+    WorkerThread::WorkerThread(bool blocking, int maxQueueItems) : mBlocking(blocking), mTaskQueue(maxQueueItems)
     {
         mRunning = false;
     }
@@ -91,7 +91,7 @@ namespace nap
     }
     
     
-    ThreadPool::ThreadPool(unsigned int numberOfThreads, unsigned int maxQueueItems, bool realTimePriority)
+    ThreadPool::ThreadPool(int numberOfThreads, int maxQueueItems, bool realTimePriority)
         : mTaskQueue(maxQueueItems), mRealTimePriority(realTimePriority)
     {
         mStop = false;

--- a/utility/src/utility/threading.cpp
+++ b/utility/src/utility/threading.cpp
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 #include "threading.h"
 
 #ifdef _WIN32

--- a/utility/src/utility/threading.h
+++ b/utility/src/utility/threading.h
@@ -29,7 +29,7 @@ namespace nap
         /**
          * Constructor takes maximum number of items that can be in the queue at a time.
          */
-        TaskQueue(unsigned int maxQueueItems = 20);
+        TaskQueue(int maxQueueItems = 20);
         /**
          * Add a task to the end of the queue.
          */
@@ -64,7 +64,7 @@ namespace nap
          *   false: the threads runs through the loop as fast as possible and emits @execute every iteration
          * @maxQueueItems: the maximum number of items in the task queue
          */
-        WorkerThread(bool blocking = true, unsigned int maxQueueItems = 20);
+        WorkerThread(bool blocking = true, int maxQueueItems = 20);
 		virtual ~WorkerThread();
         
         /**
@@ -106,7 +106,7 @@ namespace nap
     class NAPAPI ThreadPool final
 	{
     public:
-        ThreadPool(unsigned int numberOfThreads = 1, unsigned int maxQueueItems = 20, bool realTimePriority = false);
+        ThreadPool(int numberOfThreads = 1, int maxQueueItems = 20, bool realTimePriority = false);
         ~ThreadPool();
         
         /**

--- a/utility/src/utility/threading.h
+++ b/utility/src/utility/threading.h
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
 #pragma once
 
 // Local Includes

--- a/utility/src/utility/threading.h
+++ b/utility/src/utility/threading.h
@@ -7,8 +7,6 @@
 // Local Includes
 #include "blockingconcurrentqueue.h"
 
-#include <utility/dllexport.h>
-
 // External Includes
 #include <functional>
 #include <thread>
@@ -20,7 +18,7 @@ namespace nap
      * Thread safe queue for tasks that are encapsulated in function objects.
      * It is possible to enqueue tasks at the end of the queue and to execute the tasks in the queue.
      */
-    class NAPAPI TaskQueue final
+    class TaskQueue final
 	{
     public:
         // a task in the queue is a function object
@@ -56,7 +54,7 @@ namespace nap
     /**
      * A single thread that runs its own task queue
      */
-    class NAPAPI WorkerThread
+    class WorkerThread
 	{
     public:
 		/**
@@ -109,7 +107,7 @@ namespace nap
     /**
      * A pool of threads that can be used to perform multiple tasks at the same time
      */
-    class NAPAPI ThreadPool final
+    class ThreadPool final
 	{
     public:
         ThreadPool(int numberOfThreads = 1, int maxQueueItems = 20, bool realTimePriority = false);

--- a/utility/src/utility/threading.h
+++ b/utility/src/utility/threading.h
@@ -6,7 +6,8 @@
 
 // Local Includes
 #include "blockingconcurrentqueue.h"
-#include "utility/dllexport.h"
+
+#include <utility/dllexport.h>
 
 // External Includes
 #include <functional>
@@ -58,13 +59,18 @@ namespace nap
     class NAPAPI WorkerThread
 	{
     public:
-        /**
+		/**
+		 * Explicit default constructor
+		 */
+		WorkerThread();
+
+		/**
          * @blocking: 
          *   true: the threads blocks and waits for enqueued tasks to perform
          *   false: the threads runs through the loop as fast as possible and emits @execute every iteration
          * @maxQueueItems: the maximum number of items in the task queue
          */
-        WorkerThread(bool blocking = true, int maxQueueItems = 20);
+        WorkerThread(bool blocking, int maxQueueItems = 20);
 		virtual ~WorkerThread();
         
         /**


### PR DESCRIPTION
These are a couple of changes to the NAP repository made by 4DSOUND:

these will concern Naivi most:
- The AppRunner shuts down the services when the initialization fails, to ensure shutdown() is always called when init() has succeeded.
- The Parameter::setValue() functions are exposed to rtti, so they can be called form python scripts.

And these less so, as they are mainly audio changes:
- The signature of audio::MultiInputPin::pull() method has changed, so the caller has the responsibility to manage the destination buffer. This solves some threadsafety concerns while parallel processing audio.
- The host API index is passed to AudioService::openStream() method, to make sure it is updated internally when the device settings change at runtime.
- A simplification in the SafeOwner/SafePtr/DeletionQueue system, that is possible now because in NAP 0.4 order of shutdown/destruction of services is now guaranteed to mirror the service dependency graph.
- An couple of adaptations in utility/threading.h: classes are marked with NAPAPI macro to use them across DLL bounds on windows, threadpools can be marked realtime, in order to spawn their threads with realtime priority.