### PR TITLE
Napaudio fixes feb 2021

### DIFF
--- a/modules/napaudio/src/audio/component/inputcomponent.cpp
+++ b/modules/napaudio/src/audio/component/inputcomponent.cpp
@@ -15,7 +15,7 @@
 // RTTI
 RTTI_BEGIN_CLASS(nap::audio::AudioInputComponent)
 	RTTI_PROPERTY("Channels", &nap::audio::AudioInputComponent::mChannels, nap::rtti::EPropertyMetaData::Required)
-	RTTI_PROPERTY("Gain", &nap::audio::AudioInputComponent::mChannels, nap::rtti::EPropertyMetaData::Default)
+	RTTI_PROPERTY("Gain", &nap::audio::AudioInputComponent::mGain, nap::rtti::EPropertyMetaData::Default)
 RTTI_END_CLASS
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::audio::AudioInputComponentInstance)

--- a/modules/napaudio/src/audio/service/audioservice.cpp
+++ b/modules/napaudio/src/audio/service/audioservice.cpp
@@ -172,7 +172,7 @@ namespace nap
 				if (!configuration->mAllowDeviceFailure)
 				{
 					errorState.fail(
-							"Portaudio stream failed to start: %s, %s, %i inputs, %i outputs, samplerate %i, buffersize %i",
+							"Portaudio stream failed to start: %s, %s, %i inputs, %i outputs, samplerate %f, buffersize %i",
 							inputDeviceIndex >= 0 ? Pa_GetDeviceInfo(inputDeviceIndex)->name : "",
 							outputDeviceIndex >= 0 ? Pa_GetDeviceInfo(outputDeviceIndex)->name : "",
 							inputChannelCount, outputChannelCount, configuration->mSampleRate,
@@ -181,7 +181,7 @@ namespace nap
 				}
 				else {
 					Logger::info(
-							"Portaudio stream failed to start: %s, %s, %i inputs, %i outputs, samplerate %i, buffersize %i",
+							"Portaudio stream failed to start: %s, %s, %i inputs, %i outputs, samplerate %f, buffersize %i",
 							inputDeviceIndex >= 0 ? Pa_GetDeviceInfo(inputDeviceIndex)->name : "",
 							outputDeviceIndex >= 0 ? Pa_GetDeviceInfo(outputDeviceIndex)->name : "",
 							inputChannelCount, outputChannelCount, configuration->mSampleRate,
@@ -190,7 +190,7 @@ namespace nap
 				return true;
 			}
 			
-			Logger::info("Portaudio stream started: %s, %s, %i inputs, %i outputs, samplerate %i, buffersize %i",
+			Logger::info("Portaudio stream started: %s, %s, %i inputs, %i outputs, samplerate %f, buffersize %i",
 			             inputDeviceIndex >= 0 ? Pa_GetDeviceInfo(inputDeviceIndex)->name : "",
 			             outputDeviceIndex >= 0 ? Pa_GetDeviceInfo(outputDeviceIndex)->name : "",
 			             mNodeManager.getInputChannelCount(), mNodeManager.getOutputChannelCount(),


### PR DESCRIPTION
These are some bugfixes that I advice to merge into main private as well as public:
- Fix error in sample rate logging formatting by AudioService
- Fix error in property rtti definition in AudioInputComponent