### PR TITLE
Audioservice logging

### DIFF
--- a/demos/audioplayback/config.json
+++ b/demos/audioplayback/config.json
@@ -1,0 +1,9 @@
+{
+    "Objects": [
+        {
+            "Type": "nap::audio::AudioServiceConfiguration",
+            "mID": "nap::audio::AudioServiceConfiguration",
+            "DisableInput": true
+        }
+    ]
+}

--- a/demos/audioplayback/project.json
+++ b/demos/audioplayback/project.json
@@ -9,6 +9,6 @@
         "mod_napimgui"
     ],
     "Data": "data/audioplayback.json",
-    "ServiceConfig": "",
+    "ServiceConfig": "config.json",
     "PathMapping": "cache/path_mapping.json"
 }

--- a/modules/napaudio/src/audio/service/audioservice.cpp
+++ b/modules/napaudio/src/audio/service/audioservice.cpp
@@ -202,12 +202,12 @@ namespace nap
 			// Log portaudio stream settings
 			Logger::info("Portaudio stream started:");
 			if (inputDeviceIndex >= 0)
-				Logger::info("Input device: %s (%i channels)", Pa_GetDeviceInfo(inputDeviceIndex)->name, mNodeManager.getInputChannelCount());
+				Logger::info("Input device: %s, %i channel(s)", Pa_GetDeviceInfo(inputDeviceIndex)->name, mNodeManager.getInputChannelCount());
 			else
 				Logger::info("No input device");
 
 			if (outputDeviceIndex >= 0)
-				Logger::info("Output device: %s (%i channels)", Pa_GetDeviceInfo(outputDeviceIndex)->name, mNodeManager.getOutputChannelCount());
+				Logger::info("Output device: %s, %i channel(s)", Pa_GetDeviceInfo(outputDeviceIndex)->name, mNodeManager.getOutputChannelCount());
 			else
 				Logger::info("No output device");
 			Logger::info("Samplerate: %i", int(mNodeManager.getSampleRate()));
@@ -418,7 +418,7 @@ namespace nap
 				{
 					auto index = Pa_HostApiDeviceIndexToDeviceIndex(hostApi, device);
 					const PaDeviceInfo& info = *Pa_GetDeviceInfo(index);
-					nap::Logger::info("%i: %s %i inputs %i outputs", device, info.name, info.maxInputChannels,
+					nap::Logger::info("%i: %s, %i input(s) %i output(s)", device, info.name, info.maxInputChannels,
 					                  info.maxOutputChannels);
 				}
 			}

--- a/modules/napaudio/src/audio/service/audioservice.cpp
+++ b/modules/napaudio/src/audio/service/audioservice.cpp
@@ -418,7 +418,7 @@ namespace nap
 				{
 					auto index = Pa_HostApiDeviceIndexToDeviceIndex(hostApi, device);
 					const PaDeviceInfo& info = *Pa_GetDeviceInfo(index);
-					nap::Logger::info("%i: %s, %i input(s) %i output(s)", device, info.name, info.maxInputChannels,
+					nap::Logger::info("%i: %s, %i input(s), %i output(s)", device, info.name, info.maxInputChannels,
 					                  info.maxOutputChannels);
 				}
 			}

--- a/modules/napaudio/src/audio/service/audioservice.h
+++ b/modules/napaudio/src/audio/service/audioservice.h
@@ -76,9 +76,14 @@ namespace nap
 			bool mAllowDeviceFailure = true;
 			
 			/**
-			 * If set to false the audio will start with only an output device.
+			 * If set to true the audio will start with only an output device.
 			 */
 			bool mDisableInput = false;
+
+			/**
+			 * If set to true the audio will start with only an input device.
+			 */
+			bool mDisableOutput = false;
 			
 			/**
 			 * The sample rate the audio stream will run on, the number of samples processed per channel per second.


### PR DESCRIPTION
- More clear logging of audio devices and channel settings on startup
- Extra config setting for the audio service to be able to create input-only audio apps: DisableOutputs