### PR TITLE
Small changes to queue family selection in RenderService

### DIFF
--- a/modules/naprender/src/renderservice.cpp
+++ b/modules/naprender/src/renderservice.cpp
@@ -483,7 +483,7 @@ namespace nap
 			int selected_queue_idx = -1;
 			for (uint32 i = 0; i < family_queue_count; i++)
 			{
-				if (queue_properties[i].queueFlags & required_flags)
+				if ((queue_properties[i].queueFlags & required_flags) == required_flags)
 				{
 					// Make sure this family supports presentation to the given surface
 					// If running headless this check is not performed.

--- a/modules/naprender/src/renderservice.h
+++ b/modules/naprender/src/renderservice.h
@@ -56,6 +56,7 @@ namespace nap
 		bool						mHeadless = false;												///< Property: 'Headless' Render without a window. Turning this on forbids the use of a nap::RenderWindow.
 		EPhysicalDeviceType			mPreferredGPU = EPhysicalDeviceType::Discrete;					///< Property: 'PreferredGPU' The preferred type of GPU to use. When unavailable, the first GPU in the list is selected. 
 		bool						mEnableHighDPIMode = true;										///< Property: 'EnableHighDPI' If high DPI render mode is enabled, on by default
+		bool                        mRequireCompute = false;                                        ///< property: 'RequireCompute' Requires the selected queue family to support compute operations, left to false the selected queue family might support compute but not guaranteed.
 		uint32						mVulkanVersionMajor = 1;										///< Property: 'VulkanMajor The major required vulkan API instance version.
 		uint32						mVulkanVersionMinor = 0;										///< Property: 'VulkanMinor' The minor required vulkan API instance version.
 		std::vector<std::string>	mLayers = { "VK_LAYER_KHRONOS_validation" };			        ///< Property: 'Layers' Vulkan layers the engine tries to load in Debug mode. Warning is issued if the layer can't be loaded. Layers are disabled in release mode.


### PR DESCRIPTION
Fixed a bug and added the option to require a queue family that can perform compute commands.