### PR TITLE
Make use of CMAKE_OSX_ARCHITECTURES variable

### DIFF
--- a/build_tools/generate_solution/generate_solution.py
+++ b/build_tools/generate_solution/generate_solution.py
@@ -25,7 +25,8 @@ def generate(forced_path, linux_build_type, use_codeblocks):
         call(['%s -H%s -B%s -DCMAKE_BUILD_TYPE=%s' % (cmake, nap_root, build_dir, build_type)], shell=True)
     elif platform == 'darwin':
         build_dir = forced_path if forced_path else os.path.join(nap_root, MACOS_BUILD_DIR)
-        call(['%s -H%s -B%s -G Xcode' % (cmake, nap_root, build_dir)], shell=True)
+        osx_arch = '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+        call(['%s -H%s -B%s -G Xcode %s' % (cmake, nap_root, build_dir, osx_arch)], shell=True)
     else:
         build_dir = forced_path if forced_path else os.path.join(nap_root, MSVC_BUILD_DIR)
         cmd = '%s -H%s -B%s -G "Visual Studio 16 2019" -DPYBIND11_PYTHON_VERSION=3.5' % (cmake, nap_root, build_dir)

--- a/dist/user_scripts/platform/package_project_by_name.py
+++ b/dist/user_scripts/platform/package_project_by_name.py
@@ -90,6 +90,7 @@ def package_project(project_name, show_created_package, include_napkin, zip_pack
                                '-H%s' % project_path, 
                                '-B%s' % build_dir_name, 
                                '-G', 'Xcode',
+                               '-DCMAKE_OSX_ARCHITECTURES=x86_64',
                                '-DNAP_PACKAGED_APP_BUILD=1',
                                '-DPACKAGE_NAPKIN=%s' % int(include_napkin)])
 

--- a/dist/user_scripts/platform/regenerate_module_by_name.py
+++ b/dist/user_scripts/platform/regenerate_module_by_name.py
@@ -34,7 +34,8 @@ def update_module(module_name, build_type):
     if sys.platform.startswith('linux'):
         exit_code = call([cmake, '-H.', '-B%s' % BUILD_DIR, '-DCMAKE_BUILD_TYPE=%s' % build_type], cwd=module_path)
     elif sys.platform == 'darwin':
-        exit_code = call([cmake, '-H.', '-B%s' % BUILD_DIR, '-G', 'Xcode'], cwd=module_path)
+        osx_arch = '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+        exit_code = call([cmake, '-H.', '-B%s' % BUILD_DIR, '-G', 'Xcode', osx_arch], cwd=module_path)
     else:
         # Create dir if it doesn't exist
         full_build_dir = os.path.join(module_path, BUILD_DIR)

--- a/dist/user_scripts/platform/regenerate_project_by_name.py
+++ b/dist/user_scripts/platform/regenerate_project_by_name.py
@@ -36,7 +36,8 @@ def cmake_reconfigure_project(project_name, build_type, show_solution):
         #     call(["nautilus -s %s > /dev/null 2>&1 &" % BUILD_DIR], shell=True)
 
     elif sys.platform == 'darwin':
-        exit_code = call([cmake, '-H.', '-B%s' % BUILD_DIR, '-G', 'Xcode'], cwd=project_path)
+        osx_arch = '-DCMAKE_OSX_ARCHITECTURES=x86_64'
+        exit_code = call([cmake, '-H.', '-B%s' % BUILD_DIR, '-G', 'Xcode', osx_arch], cwd=project_path)
 
         # Show in Finder
         if exit_code == 0 and show_solution:


### PR DESCRIPTION
- `if (APPLE)` is skipped because this variable is ignored on other OSes
- this line is placed before `project` statement according to CMake docs
- enables APPLE branch in `targetarch.cmake`
- this change is made because all compiled libraries for MacOS are
  based on x86_64 architecture
- this option makes possible to cross-compile and run NAP-based project
  on Apple Silicon