### PR TITLE
overload PortAudioService::getDeviceInfo()

### DIFF
--- a/system_modules/napportaudio/src/audio/service/portaudioservice.cpp
+++ b/system_modules/napportaudio/src/audio/service/portaudioservice.cpp
@@ -402,9 +402,15 @@ namespace nap
 		{
 			return *Pa_GetDeviceInfo(Pa_HostApiDeviceIndexToDeviceIndex(hostApiIndex, deviceIndex));
 		}
-		
-		
-		std::vector<const PaDeviceInfo*> PortAudioService::getDevices(unsigned int hostApiIndex)
+
+
+        const PaDeviceInfo& PortAudioService::getDeviceInfo(unsigned int deviceIndex)
+        {
+            return *Pa_GetDeviceInfo(deviceIndex);
+        }
+
+
+        std::vector<const PaDeviceInfo*> PortAudioService::getDevices(unsigned int hostApiIndex)
 		{
 			std::vector<const PaDeviceInfo*> result;
 			for (auto i = 0; i < getHostApiInfo(hostApiIndex).deviceCount; ++i)

--- a/system_modules/napportaudio/src/audio/service/portaudioservice.h
+++ b/system_modules/napportaudio/src/audio/service/portaudioservice.h
@@ -191,8 +191,15 @@ namespace nap
 			 * @return reference to a record containing information about the given device
 			 */
 			const PaDeviceInfo& getDeviceInfo(unsigned int hostApiIndex, unsigned int localDeviceIndex);
-			
-			/**
+
+            /**
+             * Returns information of an audio device in a PaDeviceInfo struct defined by portaudio.
+             * @param deviceIndex: the index of the device.
+             * @return reference to a record containing information about the given device
+             */
+            const PaDeviceInfo& getDeviceInfo(unsigned int deviceIndex);
+
+            /**
 			 * Returns information on all the available devices for a given host API
 			 * @param hostApiIndex: the number of the host api
 			 * @return vector with pointers to records containing information about each device.


### PR DESCRIPTION
This overload is necessary to be able to request device info with a global index (not relative to the host index)