### PR TITLE
napvideo improvements

### DIFF
--- a/styleguide/styleguide.md
+++ b/styleguide/styleguide.md
@@ -1,6 +1,6 @@
 <br>
 <p align="center">
-  <img width=384 src="https://download.nap.tech/identity/svg/logos/nap_logo_blue.svg">
+  <img width=384 src="https://download.nap-labs.tech/identity/svg/logos/nap_logo_blue.svg">
 </p>
 
 C++ Style Guide

--- a/system_modules/napvideo/src/video.cpp
+++ b/system_modules/napvideo/src/video.cpp
@@ -800,21 +800,13 @@ namespace nap
 			else if (packet == mSeekEndPacket.get())
 			{
 				VIDEO_DEBUG_LOG("seek end received");
-                {
-                    // clear any previous frames, we're not interested in them anymore
-                    clearFrameQueue(mFrameQueue, false);
 
-                    // Copy seek frame queues into the regular frame queue
-                    while(!mSeekFrameQueue.empty())
-                    {
-                        Frame f = popSeekFrame();
-                        std::unique_lock<std::mutex> lock(mFrameQueueMutex);
-                        mFrameQueue.push(f);
-                    }
-                }
+                // clear frame queue
+                clearFrameQueue(mFrameQueue, false);
 
-                // Clear the seek frame queue
-                clearFrameQueue(mSeekFrameQueue, false);
+                // Copy seek frame queues into the regular frame queue
+                while(!mSeekFrameQueue.empty())
+                    mFrameQueue.push(popSeekFrame());
 
 				// Seeking is done, switch back to the regular frame queue so that the user can continue
 				// processing frames

--- a/system_modules/napvideo/src/video.cpp
+++ b/system_modules/napvideo/src/video.cpp
@@ -492,6 +492,8 @@ namespace nap
 
 	void AVState::waitSeekStartPacketProcessed()
 	{
+        // clear the frame queue, as we are going to seek to a new position
+        clearFrameQueue(mSeekFrameQueue, false);
 		mSeekStartProcessedEvent.wait();
 	}
 
@@ -742,12 +744,6 @@ namespace nap
 				mFrameDataAvailableCondition.notify_all();
 				VIDEO_DEBUG_LOG("push frame (stream %d): pkt_pos: %d, dts: %d, pts: %d", mStream, new_frame.mFrame->pkt_pos, new_frame.mFrame->pkt_dts, new_frame.mFrame->pkt_pts);
 			}
-
-            // sleep the thread for a bit
-            // this prevents a very rare race condition that can happen while seeking
-            // a seekstart packet can be pushed onto the queue but the decode thread is so fast that it processes the packet before waitSeekStartPacketProcessed is called
-            // this can happen with black frames in the videos and fast CPU's
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
 		}
 
 		av_frame_free(&frame);

--- a/system_modules/napvideo/src/video.cpp
+++ b/system_modules/napvideo/src/video.cpp
@@ -800,9 +800,11 @@ namespace nap
                 // clear frame queue
                 clearFrameQueue(mFrameQueue, false);
 
-                // Copy seek frame queues into the regular frame queue
-                while(!mSeekFrameQueue.empty())
-                    mFrameQueue.push(popSeekFrame());
+                // Swap seek frame queues with the regular frame queue
+                {
+                    std::unique_lock<std::mutex> lock(mFrameQueueMutex);
+                    mFrameQueue.swap(mSeekFrameQueue);
+                }
 
 				// Seeking is done, switch back to the regular frame queue so that the user can continue
 				// processing frames

--- a/system_modules/napvideo/src/video.h
+++ b/system_modules/napvideo/src/video.h
@@ -210,31 +210,30 @@ namespace nap
 		/**
 		 * Adds the 'seek start' packet to the packet queue. This functions as a command to the decode thread.
 		 */
-		bool addSeekStartPacket(const bool& exitIOThreadSignalled);
+		bool addSeekStartPacket();
 
 		/**
 		 * Adds the 'seek end' packet to the packet queue. This functions as a command to the decode thread.
 		 */
-		bool addSeekEndPacket(const bool& exitIOThreadSignalled, double seekTargetSecs);
+		bool addSeekEndPacket(double seekTargetSecs);
 
 		/**
 		 * Adds the 'end of file' packet to the packet queue. The end of file packet is a special packet
 		 * with a nullptr for data.
 		 */
-		bool addEndOfFilePacket(const bool& exitIOThreadSignalled);
+		bool addEndOfFilePacket();
 
 		/**
 		 * Adds the 'I/O finished' packet to the packet queue. This functions as a command to the decode thread.
 		 */
-		bool addIOFinishedPacket(const bool& exitIOThreadSignalled);
+		bool addIOFinishedPacket();
 
 		/**
 		 * Adds a packet to the packet queue.
 		 * @param packet The packet to add.
-		 * @param exitIOThreadSignalled When I/O thread is in exit mode, this must be true.
 		 * @return if packet was added
 		 */
-		bool addPacket(AVPacket& packet, const bool& exitIOThreadSignalled);
+		bool addPacket(AVPacket& packet);
 
 		/**
 		 * Wait for the frame to be empty

--- a/system_modules/napvideo/src/videoplayer.cpp
+++ b/system_modules/napvideo/src/videoplayer.cpp
@@ -173,10 +173,12 @@ namespace nap
 	}
 
 
-	void VideoPlayer::play(double mStartTime)
+	void VideoPlayer::play(double mStartTime, bool clearTheTextures)
 	{
 		// Clear textures and start playback
-		clearTextures();
+        if(clearTheTextures)
+		    clearTextures();
+
 		getVideo().play(mStartTime);
 	}
 

--- a/system_modules/napvideo/src/videoplayer.h
+++ b/system_modules/napvideo/src/videoplayer.h
@@ -114,8 +114,9 @@ namespace nap
 		/**
 	 	 * Starts playback of the current video at the given offset in seconds.
 		 * @param startTime The offset in seconds to start the video at.
+		 * @param clearTextures if the old textures should be cleared before starting playback.
 		 */
-		void play(double startTime = 0.0);
+		void play(double startTime = 0.0, bool clearTextures = true);
 
 		/**
 		 * Stops playback of the current video.


### PR DESCRIPTION
- This PR aims to fix a problem where video looping and seeking would not be consistent. The seek operation was discarding the seek frames, resulting in those frames to be skipped altogether and also causing synchronization issues when playing two seperate videos that need to be in sync
- Added a bool arg for video play giving the user the option to not clear the previous textures. This prevents black or green textures from being rendered when calling play or switching videos

To test : Build and run videomodulation demo, observe the perfectly looping video