### PR TITLE
Napkin Deep Copy Fix

### DIFF
--- a/demos/helloworld/data/helloworld.json
+++ b/demos/helloworld/data/helloworld.json
@@ -109,13 +109,13 @@
                     "MovementSpeed": 0.032999999821186069,
                     "RotateSpeed": 0.0032999999821186067,
                     "PerspCameraComponent": "PerspCameraComponent",
+                    "LimitZoomDistance": false,
+                    "MinimumZoomDistance": 0.5,
                     "LookAtPosition": {
                         "x": 0.0,
                         "y": 0.0,
                         "z": 0.0
-                    },
-                    "MinimumZoomDistance": 0.5,
-                    "LimitZoomDistance": false
+                    }
                 }
             ],
             "Children": []
@@ -128,6 +128,8 @@
                     "Type": "nap::Renderable2DTextComponent",
                     "mID": "nap::RenderableTextComponent",
                     "Visible": true,
+                    "Tags": [],
+                    "Layer": "",
                     "Text": "Hi there! Welcome to NAP",
                     "Font": "Font",
                     "TextColor": {
@@ -179,11 +181,71 @@
                     "Type": "nap::RenderableMeshComponent",
                     "mID": "nap::RenderableMeshComponent",
                     "Visible": true,
+                    "Tags": [],
+                    "Layer": "",
                     "Mesh": "WorldMesh",
                     "MaterialInstance": {
-                        "Uniforms": [],
-                        "Samplers": [],
+                        "Uniforms": [
+                            {
+                                "Type": "nap::UniformStruct",
+                                "mID": "UBO",
+                                "Name": "UBO",
+                                "Uniforms": [
+                                    {
+                                        "Type": "nap::UniformVec3",
+                                        "mID": "colorOne",
+                                        "Name": "colorOne",
+                                        "Value": {
+                                            "x": 0.0,
+                                            "y": 0.0,
+                                            "z": 0.0
+                                        }
+                                    },
+                                    {
+                                        "Type": "nap::UniformVec3",
+                                        "mID": "colorTwo",
+                                        "Name": "colorTwo",
+                                        "Value": {
+                                            "x": 0.0,
+                                            "y": 0.0,
+                                            "z": 0.0
+                                        }
+                                    },
+                                    {
+                                        "Type": "nap::UniformVec3",
+                                        "mID": "haloColor",
+                                        "Name": "haloColor",
+                                        "Value": {
+                                            "x": 0.0,
+                                            "y": 0.0,
+                                            "z": 0.0
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                        "Samplers": [
+                            {
+                                "Type": "nap::Sampler2D",
+                                "mID": "inWorldTexture",
+                                "Name": "inWorldTexture",
+                                "MinFilter": "Linear",
+                                "MaxFilter": "Linear",
+                                "MipMapMode": "Linear",
+                                "AddressModeVertical": "ClampToEdge",
+                                "AddressModeHorizontal": "ClampToEdge",
+                                "MinLodLevel": 0,
+                                "MaxLodLevel": 1000,
+                                "LodBias": 0.0,
+                                "AnisotropicSamples": "Default",
+                                "BorderColor": "IntOpaqueBlack",
+                                "CompareMode": "LessOrEqual",
+                                "EnableCompare": false,
+                                "Texture": "WorldTexture"
+                            }
+                        ],
                         "Buffers": [],
+                        "Constants": [],
                         "Material": "WorldMaterial",
                         "BlendMode": "NotSet",
                         "DepthMode": "NotSet"
@@ -225,6 +287,7 @@
                 {
                     "Type": "nap::RotateComponent",
                     "mID": "nap::RotateComponent",
+                    "Enabled": true,
                     "Properties": {
                         "Axis": {
                             "x": 0.0,
@@ -278,7 +341,8 @@
                     "Type": "nap::ShaderFromFile",
                     "mID": "WorldShader",
                     "VertShader": "shaders/helloworld/world.vert",
-                    "FragShader": "shaders/helloworld/world.frag"
+                    "FragShader": "shaders/helloworld/world.frag",
+                    "RestrictModuleIncludes": false
                 },
                 {
                     "Type": "nap::SphereMesh",
@@ -317,12 +381,18 @@
                             "MipMapMode": "Linear",
                             "AddressModeVertical": "ClampToEdge",
                             "AddressModeHorizontal": "ClampToEdge",
+                            "MinLodLevel": 0,
                             "MaxLodLevel": 1000,
+                            "LodBias": 0.0,
                             "AnisotropicSamples": "Default",
+                            "BorderColor": "IntOpaqueBlack",
+                            "CompareMode": "LessOrEqual",
+                            "EnableCompare": false,
                             "Texture": "WorldTexture"
                         }
                     ],
                     "Buffers": [],
+                    "Constants": [],
                     "Shader": "WorldShader",
                     "VertexAttributeBindings": [
                         {

--- a/rtti/src/rtti/factory.cpp
+++ b/rtti/src/rtti/factory.cpp
@@ -21,17 +21,17 @@ namespace nap
 		return creator->second->create();
 	}
 
+
 	rtti::Object* rtti::Factory::createDefaultObject(rtti::TypeInfo typeInfo)
 	{
 		return typeInfo.create<Object>();
 	}
 
+	
 	bool rtti::Factory::canCreate(rtti::TypeInfo typeInfo) const
 	{
 		CreatorMap::const_iterator creator = mCreators.find(typeInfo);
-		if (creator == mCreators.end())
-			return typeInfo.can_create_instance();
-
-		return true;
+		return creator != mCreators.end() ? true :
+			typeInfo.get_raw_type().is_derived_from(RTTI_OF(rtti::Object)) && typeInfo.can_create_instance();
 	}
 }

--- a/system_modules/napmath/src/rect.cpp
+++ b/system_modules/napmath/src/rect.cpp
@@ -8,12 +8,12 @@
 // External includes
 #include <glm/gtc/epsilon.hpp>
 
-RTTI_BEGIN_CLASS(nap::math::Rect)
-	RTTI_CONSTRUCTOR(float, float, float, float)
+RTTI_BEGIN_STRUCT(nap::math::Rect)
+	RTTI_VALUE_CONSTRUCTOR(float, float, float, float)
 	RTTI_CONSTRUCTOR(glm::vec2, glm::vec2)
 	RTTI_PROPERTY("Min", &nap::math::Rect::mMinPosition, nap::rtti::EPropertyMetaData::Required)
 	RTTI_PROPERTY("Max", &nap::math::Rect::mMaxPosition, nap::rtti::EPropertyMetaData::Required)
-RTTI_END_CLASS
+RTTI_END_STRUCT
 
 namespace nap
 {

--- a/system_modules/naprender/src/materialinstance.cpp
+++ b/system_modules/naprender/src/materialinstance.cpp
@@ -22,15 +22,15 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::BaseMaterialInstanceResource, "GPU 
 	RTTI_PROPERTY(nap::material::constants,		&nap::MaterialInstanceResource::mConstants,					nap::rtti::EPropertyMetaData::Embedded, "Shader specialization constant overrides")
 RTTI_END_CLASS
 
-RTTI_BEGIN_CLASS(nap::MaterialInstanceResource, "Applies a graphics material and provides an interface to override input defaults")
+RTTI_BEGIN_STRUCT(nap::MaterialInstanceResource, "Applies a graphics material and provides an interface to override input defaults")
 	RTTI_PROPERTY(nap::MaterialInstanceResource::matProperty,	&nap::MaterialInstanceResource::mMaterial,	nap::rtti::EPropertyMetaData::Required, "Graphics material default")
 	RTTI_PROPERTY("BlendMode",	&nap::MaterialInstanceResource::mBlendMode,		nap::rtti::EPropertyMetaData::Default, "Color blend mode override")
 	RTTI_PROPERTY("DepthMode",	&nap::MaterialInstanceResource::mDepthMode,		nap::rtti::EPropertyMetaData::Default, "Depth mode override")
-RTTI_END_CLASS
+RTTI_END_STRUCT
 
-RTTI_BEGIN_CLASS(nap::ComputeMaterialInstanceResource, "Applies a compute material and provides an interface to override input defaults")
+RTTI_BEGIN_STRUCT(nap::ComputeMaterialInstanceResource, "Applies a compute material and provides an interface to override input defaults")
 	RTTI_PROPERTY(nap::ComputeMaterialInstanceResource::matProperty, &nap::ComputeMaterialInstanceResource::mComputeMaterial,	nap::rtti::EPropertyMetaData::Required, "Compute material default")
-RTTI_END_CLASS
+RTTI_END_STRUCT
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::BaseMaterialInstance)
 	RTTI_FUNCTION("getOrCreateUniform", (nap::UniformStructInstance* (nap::BaseMaterialInstance::*)(const std::string&))& nap::BaseMaterialInstance::getOrCreateUniform);

--- a/tools/napkin/src/document.cpp
+++ b/tools/napkin/src/document.cpp
@@ -1134,14 +1134,14 @@ nap::rtti::Instance Document::duplicateInstance(const nap::rtti::Instance src, n
 	}
 
 	// If it's an object, handle it appropriately
-	nap::rtti::Object* obj_instance = new_instance.try_convert<nap::rtti::Object>();
+	nap::rtti::Object* obj_instance = nullptr;
 	if (new_instance.get_type().is_derived_from(RTTI_OF(nap::rtti::Object)))
 	{
 		// Give unique ID
 		nap::rtti::Object* src_obj = src.try_convert<nap::rtti::Object>(); assert(src_obj != nullptr);
 		auto parts = nap::utility::splitString(src_obj->mID, id::uuids); assert(!parts.empty());
 
-		assert(obj_instance != nullptr);
+		obj_instance = new_instance.try_convert<nap::rtti::Object>(); assert(obj_instance != nullptr);
 		obj_instance->mID = getUniqueID(parts.front(), *obj_instance, true);
 
 		// Add to managed object list
@@ -1200,8 +1200,10 @@ nap::rtti::Instance Document::duplicateInstance(const nap::rtti::Instance src, n
 		else if (property.get_type().is_derived_from(RTTI_OF(nap::MaterialInstanceResource)))
 		{
 			auto new_instance = duplicateInstance(src_value, parent);
-			auto* new_mat_instance = new_instance.try_convert<nap::MaterialInstanceResource>();
-			src_value = *new_mat_instance;
+			assert(new_instance.get_type().is_pointer());
+			auto* material_resource = new_instance.try_convert<nap::MaterialInstanceResource>();
+			src_value = *material_resource;
+			delete material_resource;
 		}
 
 		// Copy value if available

--- a/tools/napkin/src/document.cpp
+++ b/tools/napkin/src/document.cpp
@@ -1133,6 +1133,9 @@ enum class EPropertyType : nap::uint8
 };
 
 
+/**
+ * Returns the deep copy property type
+ */
 static EPropertyType getPropertyType(const nap::rtti::Property& property)
 {
 	// Embedded object
@@ -1157,9 +1160,6 @@ static EPropertyType getPropertyType(const nap::rtti::Property& property)
 
 nap::rtti::Variant Document::deepCopyInstance(const nap::rtti::Variant& src, nap::rtti::Object* parent)
 {
-	// Fetch rtti factory
-	Factory& factory = mCore.getResourceManager()->getFactory();
-
 	// Get the type to create, we support rtti objects and copy construct-able objects
 	nap::rtti::TypeInfo instance_type = src.get_type();
 	if (instance_type.is_derived_from(RTTI_OF(nap::rtti::Object)))
@@ -1169,6 +1169,7 @@ nap::rtti::Variant Document::deepCopyInstance(const nap::rtti::Variant& src, nap
 	}
 
 	// Create the new instance of object, new or copy constructed, depending on constructor type!
+	Factory& factory = mCore.getResourceManager()->getFactory();
 	nap::rtti::Variant new_instance = factory.canCreate(instance_type) ?
 		factory.create(instance_type) : src.get_type().create();
 
@@ -1209,8 +1210,8 @@ nap::rtti::Variant Document::deepCopyInstance(const nap::rtti::Variant& src, nap
 		// Get value (by copy)
 		nap::rtti::Variant value = property.get_value(src);
 
-		// Check if it's an embedded pointer or embedded pointer array ->
-		// In that case we need to deep copy the embedded object and set that.
+		// Check if it's an embedded pointer property ->
+		// In that case we need to deep copy the embedded rtti object and set that.
 		switch (getPropertyType(property))
 		{
 			case EPropertyType::EmbeddedPointer:

--- a/tools/napkin/src/document.h
+++ b/tools/napkin/src/document.h
@@ -627,7 +627,7 @@ namespace napkin
 		 * @param parent optional parent of the object, nullptr if object has no parent
 		 * @return src duplicate, nullptr if duplication failed because object can't be created
 		 */
-		nap::rtti::Object* duplicateObject(const nap::rtti::Object& src, nap::rtti::Object* parent);
+		nap::rtti::Object* duplicateInstance(const nap::rtti::Instance src, nap::rtti::Object* parent);
 	};
 
 

--- a/tools/napkin/src/document.h
+++ b/tools/napkin/src/document.h
@@ -627,7 +627,7 @@ namespace napkin
 		 * @param parent optional parent of the object, nullptr if object has no parent
 		 * @return src duplicate, nullptr if duplication failed because object can't be created
 		 */
-		nap::rtti::Object* duplicateInstance(const nap::rtti::Instance src, nap::rtti::Object* parent);
+		nap::rtti::Instance duplicateInstance(const nap::rtti::Instance src, nap::rtti::Object* parent);
 	};
 
 

--- a/tools/napkin/src/document.h
+++ b/tools/napkin/src/document.h
@@ -627,7 +627,7 @@ namespace napkin
 		 * @param parent optional parent of the object, nullptr if object has no parent
 		 * @return src duplicate, nullptr if duplication failed because object can't be created
 		 */
-		nap::rtti::Instance duplicateInstance(const nap::rtti::Instance src, nap::rtti::Object* parent);
+		nap::rtti::Variant duplicateInstance(const nap::rtti::Variant src, nap::rtti::Object* parent);
 	};
 
 

--- a/tools/napkin/src/document.h
+++ b/tools/napkin/src/document.h
@@ -622,12 +622,12 @@ namespace napkin
 		void patchLinks(nap::rtti::Object* object, const std::string& oldID, const std::string& newID, nap::rtti::Path& path);
 
 		/**
-		 * Duplicate the object, including all child properties, links and embedded pointers.
+		 * Deep copy an rtti enabled object, including all child properties, links and embedded pointers.
 		 * @param src object to duplicate
 		 * @param parent optional parent of the object, nullptr if object has no parent
-		 * @return src duplicate, nullptr if duplication failed because object can't be created
+		 * @return src duplicate, invalid variant when object can't be deep-copied
 		 */
-		nap::rtti::Variant duplicateInstance(const nap::rtti::Variant src, nap::rtti::Object* parent);
+		nap::rtti::Variant deepCopyInstance(const nap::rtti::Variant& src, nap::rtti::Object* parent);
 	};
 
 


### PR DESCRIPTION
Fixes issue: https://github.com/napframework/nap/issues/36

This PR ensures that objects (classes / structs) with embedded pointers that are _not_ of type `nap::rtti::Object` are also deep copied.