### PR TITLE
Only allow deep copy of rtti::Object* and RTTI enabled structs

### DIFF
--- a/tools/napkin/src/document.h
+++ b/tools/napkin/src/document.h
@@ -623,6 +623,7 @@ namespace napkin
 
 		/**
 		 * Deep copy an rtti enabled object, including all child properties, links and embedded pointers.
+		 * The object must be a pointer of type nap::rtti::Object or copy constructable struct
 		 * @param src object to duplicate
 		 * @param parent optional parent of the object, nullptr if object has no parent
 		 * @return src duplicate, invalid variant when object can't be deep-copied


### PR DESCRIPTION
Small improvement for: https://github.com/napframework/nap/pull/37

- Only allow deep copy of rtti::Object* and and copy constructable rtti structs
- Ensure that when we deep copy an object pointer it is of type: nap::rtti::Object
- Cleanup