### PR TITLE
Fullscreen fix

### DIFF
--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -604,10 +604,6 @@ namespace nap
 
 	void RenderWindow::toggleFullscreen()
 	{
-		// TODO: This can trigger a resize event that is handled in a new frame.
-		// causing the swap-chain to be re-created twice. Avoid this by
-		// checking against the swap extent instead of keeping flags or
-		// pushing an SDL window resize event on the stack for processing later.
 		bool cur_state = SDL::getFullscreen(mSDLWindow);
 		if(!SDL::setFullscreen(mSDLWindow, !cur_state))
 			nap::Logger::error(SDL::getSDLError());
@@ -628,10 +624,6 @@ namespace nap
 
 	void RenderWindow::setSize(const glm::ivec2& size)
 	{
-		// TODO: This can trigger a resize event that is handled in a new frame.
-		// causing the swap-chain to be re-created twice. Avoid this by
-		// checking against the swap extent instead of keeping flags or
-		// pushing an SDL window resize event on the stack for processing later.
 		if (size != SDL::getWindowSize(mSDLWindow))
 		{
 			SDL::setWindowSize(mSDLWindow, size);
@@ -994,8 +986,8 @@ namespace nap
 		VkViewport viewport = {};
 		viewport.x = 0.0f;
 		viewport.y = 0.0f;
-		viewport.width = mSwapchainExtent.width;
-		viewport.height = mSwapchainExtent.height;
+		viewport.width = static_cast<float>(mSwapchainExtent.width);
+		viewport.height = static_cast<float>(mSwapchainExtent.height);
 		viewport.minDepth = 0.0f;
 		viewport.maxDepth = 1.0f;
 		vkCmdSetViewport(mCommandBuffers[current_frame], 0, 1, &viewport);
@@ -1034,8 +1026,8 @@ namespace nap
 		{
 			mSwapchainExtent =
 			{
-				math::clamp<uint32>((uint32)buffer_size.x, mSurfaceCapabilities.minImageExtent.width,  mSurfaceCapabilities.maxImageExtent.width),
-				math::clamp<uint32>((uint32)buffer_size.y, mSurfaceCapabilities.minImageExtent.height, mSurfaceCapabilities.maxImageExtent.height),
+				math::clamp<uint32>(static_cast<uint32>(buffer_size.x), mSurfaceCapabilities.minImageExtent.width,  mSurfaceCapabilities.maxImageExtent.width),
+				math::clamp<uint32>(static_cast<uint32>(buffer_size.y), mSurfaceCapabilities.minImageExtent.height, mSurfaceCapabilities.maxImageExtent.height),
 			};
 		}
 		else

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -741,7 +741,6 @@ namespace nap
 		VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, mImageAvailableSemaphores[current_frame], VK_NULL_HANDLE, &mCurrentImageIndex);
 		if (result == VK_ERROR_OUT_OF_DATE_KHR)
 		{
-			nap::Logger::warn("Unable to acquire next presentable image, surface not compatible with swapchain");
 			mRecreateSwapchain = true;
 			return VK_NULL_HANDLE;
 		}
@@ -829,7 +828,6 @@ namespace nap
             break;
 		case VK_ERROR_OUT_OF_DATE_KHR:
 		case VK_SUBOPTIMAL_KHR:
-			nap::Logger::warn("Unable to queue surface for presentation, surface not compatible with swapchain");
 			mRecreateSwapchain = true;
 			break;
 		default:

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -597,8 +597,8 @@ namespace nap
 
 	void RenderWindow::setFullscreen(bool value)
 	{
-		if (SDL::getFullscreen(mSDLWindow) != value)
-			toggleFullscreen();
+		if(!SDL::setFullscreen(mSDLWindow, value))
+			nap::Logger::error(SDL::getSDLError());
 	}
 
 

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -1021,9 +1021,9 @@ namespace nap
 			return false;
 
 		// Based on surface capabilities, determine swap image size
-		glm::ivec2 buffer_size = this->getBufferSize();
 		if (mSurfaceCapabilities.currentExtent.width == UINT32_MAX)
 		{
+			glm::ivec2 buffer_size = this->getBufferSize();
 			mSwapchainExtent =
 			{
 				math::clamp<uint32>(static_cast<uint32>(buffer_size.x), mSurfaceCapabilities.minImageExtent.width,  mSurfaceCapabilities.maxImageExtent.width),

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -345,5 +345,10 @@ namespace nap
 		 * @return if the swapchain extent is higher than zero in both axis
 		 */
 		bool validSwapchainExtent() const;
+
+		/**
+		 * Checks if the event is a window resize event and updates size accordingly.
+		 */
+		void handleEvent(const Event& event);
 	};
 }

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -275,7 +275,7 @@ namespace nap
 		ERasterizationSamples	mRequestedSamples	= ERasterizationSamples::Four;		///< Property: 'Samples' The number of samples used during Rasterization. For even better results enable 'SampleShading'.
 		int						mAddedSwapImages	= 1;								///< Property: 'AdditionalSwapImages' number of additional swapchain images to create, added to minimum specified by hardware.
 		bool					mRestorePosition	= true;								///< Property: 'RestorePosition' if window position is restored from previous session
-		bool					mRestoreSize		= true;								///< Property: 'RestoreSize' if window size is restored from previous session
+		bool					mRestoreSize		= true;								///< Property: 'RestoreSize' if window size is restored from previous session	
 
 	private:
 		RenderService*					mRenderService	= nullptr;
@@ -302,6 +302,7 @@ namespace nap
 		bool							mRecreateSwapchain = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;
 		VkExtent2D						mSwapchainExtent = {0,0};
+		bool							mToggleFullscreen = false;
 
 		/**
 		 * Called by the render service. 

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -300,6 +300,7 @@ namespace nap
 		uint32							mCurrentImageIndex = 0;
 		uint32							mSwapChainImageCount = 0;
 		bool							mRecreateSwapchain = false;
+		bool							mWindowDirty = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;
 		VkExtent2D						mSwapchainExtent = {0,0};
 		bool							mToggleFullscreen = false;

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -300,10 +300,8 @@ namespace nap
 		uint32							mCurrentImageIndex = 0;
 		uint32							mSwapChainImageCount = 0;
 		bool							mRecreateSwapchain = false;
-		bool							mWindowDirty = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;
 		VkExtent2D						mSwapchainExtent = {0,0};
-		bool							mToggleFullscreen = false;
 
 		/**
 		 * Called by the render service. 
@@ -318,11 +316,6 @@ namespace nap
 		 * Ends the recording operation, submits the queue and asks for presentation.
 		 */
 		void endRecording();
-		
-		/**
-		 * Checks if the event is a window resize event and updates size accordingly.
-		 */
-		void handleEvent(const Event& event);
 
 		/**
 		 * Obtain the surface properties that are required for the creation of the swap chain 

--- a/system_modules/naprender/src/sdlhelpers.cpp
+++ b/system_modules/naprender/src/sdlhelpers.cpp
@@ -56,11 +56,11 @@ namespace nap
 		}
 
 
-		void setFullscreen(SDL_Window* window, bool value)
+		bool setFullscreen(SDL_Window* window, bool value)
 		{
 			// Otherwise set
 			uint32 full_screen_flag = SDL_WINDOW_FULLSCREEN_DESKTOP;
-			SDL_SetWindowFullscreen(window, value ? full_screen_flag : 0);
+			return SDL_SetWindowFullscreen(window, value ? full_screen_flag : 0) == 0;
 		}
 
 
@@ -129,7 +129,7 @@ namespace nap
 		// Returns the last SDL error
 		std::string getSDLError()
 		{
-			return std::string(SDL_GetError());
+			return SDL_GetError();
 		}
 
 

--- a/system_modules/naprender/src/sdlhelpers.h
+++ b/system_modules/naprender/src/sdlhelpers.h
@@ -35,8 +35,9 @@ namespace nap
 		 * Sets the window to be full screen in desktop mode
 		 * @param window the window to enable / disable
 		 * @param value if the window is full screen
+		 * @return if full screen operation succeeded
 		 */
-		void NAPAPI setFullscreen(SDL_Window* window, bool value);
+		bool NAPAPI setFullscreen(SDL_Window* window, bool value);
 
 		/**
 		 * Returns if the window is full screen (Desktop)


### PR DESCRIPTION
This PR fixes [setFullScreen on windows and linux](https://github.com/napframework/nap/issues/33)

The main culprit was inside `RenderWindow::beginRendering()`, where it would use the current window bounds instead of the swap chain extend for setting up the render pass, causing the subsequent vulkan render calls to fail when (out of session) the window was resized, because the render-window could be larger than the allocated surface.

By making sure the render area matches the assigned swap-chain-extent we know for sure the render pass will succeed, but updating the display queue or requesting an image index could fail because the surface could be out of sync with the swap-chain , but that's ok: we take that as a hint for re-creating the swapchain the next frame.

As a safety I also handle window resize events, which are processed at the beginning of a new frame, ensuring the render-chain is only rebuild once.

Tested on Ubuntu 24.04 and Windows.