### PR TITLE
RTTI Register ivec4 and add GPUBufferIVec4

### DIFF
--- a/system_modules/napmath/src/mathattributes.cpp
+++ b/system_modules/napmath/src/mathattributes.cpp
@@ -110,6 +110,15 @@ RTTI_BEGIN_STRUCT(glm::ivec3)
 	RTTI_CUSTOM_REGISTRATION_FUNCTION(sRegisterIntVectorOperators)
 RTTI_END_STRUCT
 
+RTTI_BEGIN_STRUCT(glm::ivec4)
+	RTTI_VALUE_CONSTRUCTOR(int, int, int, int)
+	RTTI_PROPERTY("x", &glm::ivec4::x, nap::rtti::EPropertyMetaData::Default)
+	RTTI_PROPERTY("y", &glm::ivec4::y, nap::rtti::EPropertyMetaData::Default)
+	RTTI_PROPERTY("z", &glm::ivec4::z, nap::rtti::EPropertyMetaData::Default)
+	RTTI_PROPERTY("w", &glm::ivec4::w, nap::rtti::EPropertyMetaData::Default)
+	RTTI_CUSTOM_REGISTRATION_FUNCTION(sRegisterIntVectorOperators)
+RTTI_END_STRUCT
+
 RTTI_BEGIN_STRUCT(glm::quat)
 	RTTI_VALUE_CONSTRUCTOR(float, float, float, float)
 	RTTI_PROPERTY("x", &glm::quat::x, nap::rtti::EPropertyMetaData::Default)

--- a/system_modules/naprender/src/bufferbindinginstance.cpp
+++ b/system_modules/naprender/src/bufferbindinginstance.cpp
@@ -53,11 +53,11 @@ namespace nap
 	template<typename INSTANCE_TYPE, typename RESOURCE_TYPE, typename DECLARATION_TYPE>
 	std::unique_ptr<INSTANCE_TYPE> BufferBindingInstance::createBufferBindingInstance(const std::string& bindingName, const DECLARATION_TYPE& declaration, const BufferBinding* binding, BufferBindingChangedCallback bufferChangedCallback, utility::ErrorState& errorState)
 	{
-		std::unique_ptr<INSTANCE_TYPE> result = std::make_unique<INSTANCE_TYPE>(bindingName, declaration, bufferChangedCallback);
+		auto result = std::make_unique<INSTANCE_TYPE>(bindingName, declaration, bufferChangedCallback);
 		if (binding != nullptr)
 		{
-			const RESOURCE_TYPE* typed_resource = rtti_cast<const RESOURCE_TYPE>(binding);
-			if (!errorState.check(typed_resource != nullptr, "Encountered type mismatch between uniform in material and uniform in shader"))
+			const auto* typed_resource = rtti_cast<const RESOURCE_TYPE>(binding);
+			if (!errorState.check(typed_resource != nullptr, "Encountered type mismatch between uniform in material and uniform in shader (%s)", declaration.mName.c_str()))
 				return nullptr;
 
 			result->mBuffer = typed_resource->mBuffer.get();

--- a/system_modules/naprender/src/formatutils.cpp
+++ b/system_modules/naprender/src/formatutils.cpp
@@ -41,7 +41,8 @@ namespace nap
 			{RTTI_OF(float),		VkFormat::VK_FORMAT_R32_SFLOAT},
 			{RTTI_OF(glm::vec2),	VkFormat::VK_FORMAT_R32G32_SFLOAT},
 			{RTTI_OF(glm::vec3),	VkFormat::VK_FORMAT_R32G32B32_SFLOAT},
-			{RTTI_OF(glm::vec4),	VkFormat::VK_FORMAT_R32G32B32A32_SFLOAT}
+			{RTTI_OF(glm::vec4),	VkFormat::VK_FORMAT_R32G32B32A32_SFLOAT},
+			{RTTI_OF(glm::ivec4),	VkFormat::VK_FORMAT_R32G32B32A32_SINT}
 		};
 
 		const auto it = format_table.find(type);

--- a/system_modules/naprender/src/gpubuffer.cpp
+++ b/system_modules/naprender/src/gpubuffer.cpp
@@ -81,6 +81,12 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::GPUBufferVec4, "Vector (vec4) GPU b
 	RTTI_PROPERTY("FillPolicy", &nap::GPUBufferVec4::mFillPolicy,	nap::rtti::EPropertyMetaData::Default, "Optional buffer fill rule")
 RTTI_END_CLASS
 
+RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::GPUBufferIVec4, "Integer Vector 4 (ivec4) GPU buffer")
+	RTTI_CONSTRUCTOR(nap::Core&)
+	RTTI_PROPERTY("Clear",		&nap::GPUBufferIVec4::mClear,		nap::rtti::EPropertyMetaData::Default, "Clear to zero if no fill policy is set")
+	RTTI_PROPERTY("FillPolicy", &nap::GPUBufferIVec4::mFillPolicy,	nap::rtti::EPropertyMetaData::Default, "Optional buffer fill rule")
+RTTI_END_CLASS
+
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::GPUBufferMat4, "Matrix (4x4) GPU buffer")
 	RTTI_CONSTRUCTOR(nap::Core&)
 	RTTI_PROPERTY("Clear",		&nap::GPUBufferMat4::mClear,		nap::rtti::EPropertyMetaData::Default, "Clear to zero if no fill policy is set")
@@ -116,6 +122,9 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::VertexBufferVec4, "Vector (vec4) GP
 	RTTI_CONSTRUCTOR(nap::Core&)
 RTTI_END_CLASS
 
+RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::VertexBufferIVec4, "Integer Vector 4 (ivec4) GPU vertex buffer")
+	RTTI_CONSTRUCTOR(nap::Core&)
+RTTI_END_CLASS
 
 //////////////////////////////////////////////////////////////////////////
 // IndexBuffer

--- a/system_modules/naprender/src/gpubuffer.h
+++ b/system_modules/naprender/src/gpubuffer.h
@@ -476,6 +476,7 @@ namespace nap
 	using GPUBufferVec2			= TypedGPUBufferNumeric<glm::vec2>;
 	using GPUBufferVec3			= TypedGPUBufferNumeric<glm::vec3>;
 	using GPUBufferVec4			= TypedGPUBufferNumeric<glm::vec4>;
+	using GPUBufferIVec4		= TypedGPUBufferNumeric<glm::ivec4>;
 	using GPUBufferMat4			= TypedGPUBufferNumeric<glm::mat4>;
 
 	// Vertex GPU buffers
@@ -485,7 +486,7 @@ namespace nap
 	using VertexBufferVec2		= VertexBuffer<glm::vec2>;
 	using VertexBufferVec3		= VertexBuffer<glm::vec3>;
 	using VertexBufferVec4		= VertexBuffer<glm::vec4>;
-
+	using VertexBufferIVec4		= VertexBuffer<glm::ivec4>;
 
 	//////////////////////////////////////////////////////////////////////////
 	// Template Definitions

--- a/system_modules/naprender/src/mesh.cpp
+++ b/system_modules/naprender/src/mesh.cpp
@@ -102,12 +102,15 @@ namespace nap
 
 			else if (mesh_attribute->get_type() == RTTI_OF(Vec2VertexAttribute))
 				buffer = &mGPUMesh->addVertexBuffer<glm::vec2>(mesh_attribute->mAttributeID);
-
+			
 			else if (mesh_attribute->get_type() == RTTI_OF(Vec3VertexAttribute))
 				buffer = &mGPUMesh->addVertexBuffer<glm::vec3>(mesh_attribute->mAttributeID);
 
 			else if (mesh_attribute->get_type() == RTTI_OF(Vec4VertexAttribute))
 				buffer = &mGPUMesh->addVertexBuffer<glm::vec4>(mesh_attribute->mAttributeID);
+			
+			else if (mesh_attribute->get_type() == RTTI_OF(IVec4VertexAttribute))
+				buffer = &mGPUMesh->addVertexBuffer<glm::ivec4>(mesh_attribute->mAttributeID);
 
 			else
 			{

--- a/system_modules/naprender/src/shadervariabledeclarations.h
+++ b/system_modules/naprender/src/shadervariabledeclarations.h
@@ -44,7 +44,7 @@ namespace nap
 		Vec2,				///< 2 float vector
 		Vec3,				///< 3 float vector
 		Vec4,				///< 4 float vector
-		IVec4,				///< 4 int vector
+		IVec4,				///< 4 signed int vector
 		UVec4,				///< 4 uint vector
 		Mat2,				///< 2x2 float matrix
 		Mat3,				///< 3x3 float matrix

--- a/system_modules/naprender/src/uniforminstance.cpp
+++ b/system_modules/naprender/src/uniforminstance.cpp
@@ -124,11 +124,11 @@ namespace nap
 	template<typename INSTANCE_TYPE, typename RESOURCE_TYPE, typename DECLARATION_TYPE>
 	static std::unique_ptr<INSTANCE_TYPE> createUniformValueInstance(const Uniform* value, const DECLARATION_TYPE& declaration, utility::ErrorState& errorState)
 	{
-		std::unique_ptr<INSTANCE_TYPE> result = std::make_unique<INSTANCE_TYPE>(declaration);
+		auto result = std::make_unique<INSTANCE_TYPE>(declaration);
 		if (value != nullptr)
 		{
-			const RESOURCE_TYPE* typed_resource = rtti_cast<const RESOURCE_TYPE>(value);
-			if (!errorState.check(typed_resource != nullptr, "Encountered type mismatch between uniform in material and uniform in shader"))
+			const auto* typed_resource = rtti_cast<const RESOURCE_TYPE>(value);
+			if (!errorState.check(typed_resource != nullptr, "Encountered type mismatch between uniform in material and uniform in shader (%s)", declaration.mName.c_str()))
 				return nullptr;
 
 			result->set(*typed_resource);

--- a/system_modules/naprender/src/vertexattribute.cpp
+++ b/system_modules/naprender/src/vertexattribute.cpp
@@ -34,6 +34,10 @@ RTTI_BEGIN_CLASS(nap::Vec4VertexAttribute)
 	RTTI_PROPERTY("Data", &nap::Vec4VertexAttribute::mData, nap::rtti::EPropertyMetaData::Required, "Vector (vec4) vertex data")
 RTTI_END_CLASS
 
+RTTI_BEGIN_CLASS(nap::IVec4VertexAttribute)
+	RTTI_PROPERTY("Data", &nap::IVec4VertexAttribute::mData, nap::rtti::EPropertyMetaData::Required, "Integer vector (ivec4) vertex data")
+RTTI_END_CLASS
+
 namespace nap
 {
 	// Only here to make sure this cpp is not removed during optimization, which would cause the RTTI definitions to be missing
@@ -60,4 +64,7 @@ namespace nap
 
 	template<>
 	VkFormat Vec4VertexAttribute::getFormat() const { return VK_FORMAT_R32G32B32A32_SFLOAT; }
+
+	template<>
+	VkFormat IVec4VertexAttribute::getFormat() const { return VK_FORMAT_R32G32B32A32_SINT; }
 }

--- a/system_modules/naprender/src/vertexattribute.h
+++ b/system_modules/naprender/src/vertexattribute.h
@@ -170,7 +170,8 @@ namespace nap
 	using Vec2VertexAttribute	= VertexAttribute<glm::vec2>;
 	using Vec3VertexAttribute	= VertexAttribute<glm::vec3>;
 	using Vec4VertexAttribute	= VertexAttribute<glm::vec4>;
-
+	using IVec4VertexAttribute	= VertexAttribute<glm::ivec4>;
+	
 
 	//////////////////////////////////////////////////////////////////////////
 	// Template Definitions
@@ -220,5 +221,7 @@ namespace nap
 	template<>
 	NAPAPI VkFormat Vec4VertexAttribute::getFormat() const;
 
+	template<>
+	NAPAPI VkFormat IVec4VertexAttribute::getFormat() const;
 } // nap
 


### PR DESCRIPTION
Useful for (signed) integer storage buffers that require 16-byte alignment