### PR TITLE
Output useful error message when shader file includer fails

### DIFF
--- a/system_modules/naprender/src/shader.cpp
+++ b/system_modules/naprender/src/shader.cpp
@@ -266,7 +266,10 @@ public:
 
 		auto absolute_path = nap::utility::findFileInDirectories(headerName, { shader_search_paths });
 		if (absolute_path.empty())
-			return nullptr;
+        {
+            NAP_ASSERT_MSG(false, nap::utility::stringFormat("Failed to find shader include file with name `%s` when parsing shader `%s`", headerName, includerName).c_str());
+            return nullptr;
+        }
 
 		nap::utility::ErrorState error_state;
 		auto& header_source = mHeaderSources.emplace();
@@ -280,7 +283,10 @@ public:
 	// specified IncludeResult.
 	virtual void releaseInclude(glslang::TShader::Includer::IncludeResult* includer) override
 	{
-		assert(includer == &mResults.top());
+        // This will result in a shader parse error later
+		if (includer != &mResults.top())
+            return;
+
 		mResults.pop();
 		mHeaderSources.pop();
 	}

--- a/system_modules/naprender/src/shader.cpp
+++ b/system_modules/naprender/src/shader.cpp
@@ -267,7 +267,7 @@ public:
 		auto absolute_path = nap::utility::findFileInDirectories(headerName, { shader_search_paths });
 		if (absolute_path.empty())
         {
-            NAP_ASSERT_MSG(false, nap::utility::stringFormat("Failed to find shader include file with name `%s` when parsing shader `%s`", headerName, includerName).c_str());
+            nap::Logger::warn("Failed to find shader include file with name `%s` when parsing shader `%s`", headerName, includerName);
             return nullptr;
         }
 
@@ -283,7 +283,7 @@ public:
 	// specified IncludeResult.
 	virtual void releaseInclude(glslang::TShader::Includer::IncludeResult* includer) override
 	{
-        // This will result in a shader parse error later
+        // glslang will raise a shader parse error if the include result is not released
 		if (includer != &mResults.top())
             return;
 

--- a/system_modules/naprender/src/shader.cpp
+++ b/system_modules/naprender/src/shader.cpp
@@ -267,14 +267,17 @@ public:
 		auto absolute_path = nap::utility::findFileInDirectories(headerName, { shader_search_paths });
 		if (absolute_path.empty())
         {
-            nap::Logger::warn("Failed to find shader include file with name `%s` when parsing shader `%s`", headerName, includerName);
+            nap::Logger::error("Failed to find shader include file with name `%s` when parsing shader `%s`", headerName, includerName);
             return nullptr;
         }
 
 		nap::utility::ErrorState error_state;
 		auto& header_source = mHeaderSources.emplace();
 		if (!error_state.check(nap::utility::readFileToString(absolute_path, header_source, error_state), "Unable to read shader file %s", absolute_path.c_str()))
+		{
+			nap::Logger::error(error_state.toString());
 			return nullptr;
+		}
 
 		return &mResults.emplace(absolute_path, header_source.c_str(), header_source.size(), this);
 	}


### PR DESCRIPTION
Assert with useful error message when shader file includer fails. Return from `releaseInclude` instead of empty `assert`, `glslang` asserts with a more descriptive error message later as well.