### PR TITLE
Fix RMS calculation

### DIFF
--- a/system_modules/napaudio/src/audio/component/levelmetercomponent.h
+++ b/system_modules/napaudio/src/audio/component/levelmetercomponent.h
@@ -37,7 +37,7 @@ namespace nap
 
 			nap::ComponentPtr<AudioComponentBase> mInput; ///< property: 'Input' The component whose audio output will be measured.
 			TimeValue mAnalysisWindowSize = 10; ///< property: 'AnalysisWindowSize' Size of an analysis window in milliseconds.
-			LevelMeterNode::Type mMeterType = LevelMeterNode::Type::RMS; ///< property: 'MeterType' Type of analysis to be used: RMS for root mean square, PEAK for the peak of the analysis window.
+			LevelMeterNode::EType mMeterType = LevelMeterNode::EType::RMS; ///< property: 'MeterType' Type of analysis to be used: RMS for root mean square, PEAK for the peak of the analysis window.
 			bool mFilterInput = false; ///< If set to true the input signal will be filtered before being measured.
 			ControllerValue mCenterFrequency = 10000.f; ///< property: 'CenterFrequency' Center frequency of the frequency band that will be analyzed. Only has effect when mFilterInput = true.
 			ControllerValue mBandWidth = 10000.f; ///< property: 'BandWidth' Width in Hz of the frequency band that will be analyzed. Only has effect when mFilterInput = true.

--- a/system_modules/napaudio/src/audio/node/levelmeternode.cpp
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.cpp
@@ -42,7 +42,7 @@ namespace nap
 
 		float LevelMeterNode::getLevel()
 		{
-			return mType == RMS ? sqrt(mValue.load()) : mValue.load();
+			return mType == Type::RMS ? std::sqrt(mValue.load()) : mValue.load();
 		}
 
 
@@ -55,7 +55,7 @@ namespace nap
             
 			switch (mType)
 			{
-				case PEAK:
+				case Type::PEAK:
 					for (auto& sample : *inputBuffer)
 					{
 						// keep track of peak, sample by sample

--- a/system_modules/napaudio/src/audio/node/levelmeternode.cpp
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.cpp
@@ -7,9 +7,9 @@
 #include <audio/core/audionodemanager.h>
 #include <cmath>
 
-RTTI_BEGIN_ENUM(nap::audio::LevelMeterNode::Type)
-	RTTI_ENUM_VALUE(nap::audio::LevelMeterNode::Type::RMS, "RMS"),
-	RTTI_ENUM_VALUE(nap::audio::LevelMeterNode::Type::PEAK, "Peak")
+RTTI_BEGIN_ENUM(nap::audio::LevelMeterNode::EType)
+	RTTI_ENUM_VALUE(nap::audio::LevelMeterNode::EType::RMS, "RMS"),
+	RTTI_ENUM_VALUE(nap::audio::LevelMeterNode::EType::PEAK, "Peak")
 RTTI_END_ENUM
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::audio::LevelMeterNode)
@@ -42,7 +42,7 @@ namespace nap
 
 		float LevelMeterNode::getLevel()
 		{
-			return mType == Type::RMS ? std::sqrt(mValue.load()) : mValue.load();
+			return mType == EType::RMS ? std::sqrt(mValue.load()) : mValue.load();
 		}
 
 
@@ -55,7 +55,7 @@ namespace nap
             
 			switch (mType)
 			{
-				case Type::PEAK:
+				case EType::PEAK:
 					for (auto& sample : *inputBuffer)
 					{
 						// keep track of peak, sample by sample

--- a/system_modules/napaudio/src/audio/node/levelmeternode.cpp
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.cpp
@@ -42,7 +42,7 @@ namespace nap
 
 		float LevelMeterNode::getLevel()
 		{
-			return mValue.load();
+			return mType == RMS ? sqrt(mValue.load()) : mValue.load();
 		}
 
 

--- a/system_modules/napaudio/src/audio/node/levelmeternode.h
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.h
@@ -29,7 +29,7 @@ namespace nap
 		class NAPAPI LevelMeterNode : public Node
 		{
 		public:
-			enum Type
+			enum class Type
 			{
 				PEAK, RMS
 			};

--- a/system_modules/napaudio/src/audio/node/levelmeternode.h
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.h
@@ -29,7 +29,7 @@ namespace nap
 		class NAPAPI LevelMeterNode : public Node
 		{
 		public:
-			enum class Type
+			enum class EType
 			{
 				PEAK, RMS
 			};
@@ -53,7 +53,7 @@ namespace nap
 			/**
 			 * Set the Type of the analysis. PEAK means the highest absolute amplitude within the analyzed window will be output. RMS means the root mean square of all values within the analyzed window will be output.
 			 */
-			void setType(Type type) { mType = type; }
+			void setType(EType type) { mType = type; }
 
 			// Inherited from Node
 			void process() override;
@@ -61,7 +61,7 @@ namespace nap
 
 		private:
 			int mIndex = 0; // Current write index of the buffer being analyzed.
-			Type mType = Type::RMS; // Algorithm currently being used to calculate the output level value from one buffer.
+			EType mType = EType::RMS; // Algorithm currently being used to calculate the output level value from one buffer.
 			TimeValue mAnalysisWindowSize = 0.f;
 			int mWindowSizeInSamples = 0;
 			std::atomic<float> mValue = 0.f; // Calculated output level value


### PR DESCRIPTION
I accidentally omitted a square root when rewriting the RMS implementation in LevelMeterNode. With this PR it is re-added.

I decided to add the sqrt() call in the getter to not impact audio thread performance.