### PR TITLE
Fix crash in OSCSender when UdpTransmitSocket throws uncaught exception in constructor

### DIFF
--- a/system_modules/naposc/src/oscsender.cpp
+++ b/system_modules/naposc/src/oscsender.cpp
@@ -15,6 +15,7 @@ RTTI_BEGIN_CLASS(nap::OSCSender, "Sends OSC messages over the network")
 	RTTI_PROPERTY("IpAddress", &nap::OSCSender::mIPAddress, nap::rtti::EPropertyMetaData::Default, "Target machine IP address")
 	RTTI_PROPERTY("Port", &nap::OSCSender::mPort, nap::rtti::EPropertyMetaData::Required, "Target machine port")
 	RTTI_PROPERTY("BufferScale", &nap::OSCSender::mBufferScale, nap::rtti::EPropertyMetaData::Default, "Scale factor applied to OSC message buffer")
+    RTTI_PROPERTY("AllowFailure", &nap::OSCSender::mAllowFailure, nap::rtti::EPropertyMetaData::Default, "Successful initialization even if UDP socket can not be created")
 RTTI_END_CLASS
 
 // Max size in bytes of an OSC message
@@ -31,9 +32,21 @@ namespace nap
 		char hostIpAddress[IpEndpointName::ADDRESS_STRING_LENGTH];
 		host.AddressAsString(hostIpAddress);
 
-		// Create socket
-		mSocket = std::make_unique<UdpTransmitSocket>(host);
-		nap::Logger::info("Started OSC output connection, ip: %s, port: %d", hostIpAddress, mPort);
+		// Try to create the socket
+        mSocket = nullptr;
+        try
+        {
+            mSocket = std::make_unique<UdpTransmitSocket>(host);
+            nap::Logger::info("Started OSC output connection, ip: %s, port: %d", hostIpAddress, mPort);
+        }catch (const std::exception& e)
+        {
+            // Exception can be thrown in constructor of UdpTransmitSocket, caught here
+            // If we allow failure, log the error, otherwise return false and fail initialization
+            if(!errorState.check(mAllowFailure, "Failed to start OSC output connection, ip: %s, port: %d, error: %s", hostIpAddress, mPort, e.what()))
+                return false;
+
+            nap::Logger::error("Failed to start OSC output connection, ip: %s, port: %d, error: %s", hostIpAddress, mPort, e.what());
+        }
 
 		return true;
 	}
@@ -41,12 +54,16 @@ namespace nap
 
 	void OSCSender::stop()
 	{
-		mSocket.reset(nullptr);
-	}
+        if(mSocket!=nullptr)
+            mSocket.reset(nullptr);
+    }
 
 
 	bool OSCSender::send(const OSCEvent& oscEvent)
 	{
+        if(!mSocket)
+            return false;
+
 		std::size_t buffer_size = oscEvent.getSize();
 		buffer_size *= math::max<int>(mBufferScale, 1);
 		buffer_size += sizeof(osc::BeginMessage);
@@ -71,7 +88,10 @@ namespace nap
 
 	void OSCSender::sendQueuedEvents()
 	{
-		if (mEventQueue.empty())
+        if(!mSocket)
+            return;
+
+		if(mEventQueue.empty())
 			return;
 
 		// Create the buffer
@@ -93,7 +113,7 @@ namespace nap
 		packet << osc::BeginBundle();
 
 		// Add all events
-		while (!(mEventQueue.empty()))
+		while(!(mEventQueue.empty()))
 		{
 			writeToPacket(*(mEventQueue.front().get()), packet);
 			mEventQueue.pop();
@@ -117,7 +137,7 @@ namespace nap
 		outPacket << osc::BeginMessage(oscEvent.getAddress().c_str());
 
 		// Add every argument
-		for (const auto& arg : oscEvent.getArguments())
+		for(const auto& arg : oscEvent.getArguments())
 		{
 			arg->add(outPacket);
 		}
@@ -129,6 +149,9 @@ namespace nap
 
 	void OSCSender::addEvent(OSCEventPtr oscEvent)
 	{
+        if(!mSocket)
+            return;
+
 		mEventQueueDataSize += (oscEvent->getSize());
 		mEventQueue.emplace(std::move(oscEvent));
 	}

--- a/system_modules/naposc/src/oscsender.cpp
+++ b/system_modules/naposc/src/oscsender.cpp
@@ -54,14 +54,14 @@ namespace nap
 
 	void OSCSender::stop()
 	{
-        if(mSocket!=nullptr)
+        if(mSocket==nullptr)
             mSocket.reset(nullptr);
     }
 
 
 	bool OSCSender::send(const OSCEvent& oscEvent)
 	{
-        if(mSocket!=nullptr)
+        if(mSocket==nullptr)
             return false;
 
 		std::size_t buffer_size = oscEvent.getSize();
@@ -88,7 +88,7 @@ namespace nap
 
 	void OSCSender::sendQueuedEvents()
 	{
-        if(!mSocket)
+        if(mSocket== nullptr)
             return;
 
 		if(mEventQueue.empty())
@@ -149,7 +149,7 @@ namespace nap
 
 	void OSCSender::addEvent(OSCEventPtr oscEvent)
 	{
-        if(mSocket!=nullptr)
+        if(mSocket==nullptr)
             return;
 
 		mEventQueueDataSize += (oscEvent->getSize());

--- a/system_modules/naposc/src/oscsender.cpp
+++ b/system_modules/naposc/src/oscsender.cpp
@@ -61,7 +61,7 @@ namespace nap
 
 	bool OSCSender::send(const OSCEvent& oscEvent)
 	{
-        if(!mSocket)
+        if(mSocket!=nullptr)
             return false;
 
 		std::size_t buffer_size = oscEvent.getSize();
@@ -71,7 +71,7 @@ namespace nap
 
 		// Grow the buffer based on the number of bytes that need allocation
 		// Always allocate more than the bare minimum, that's why we multiply by 2.
-		if (mBuffer.size() < buffer_size)
+		if(mBuffer.size() < buffer_size)
 			mBuffer.resize(buffer_size);
 
 		// Create packet
@@ -103,7 +103,7 @@ namespace nap
 		buffer_size += sizeof(osc::BundleTerminator);
 
 		// Grow the buffer based on the number of bytes that need allocation
-		if (mBuffer.size() < buffer_size)
+		if(mBuffer.size() < buffer_size)
 			mBuffer.resize(buffer_size);
 
 		// Create packet, grow buffer if necessary
@@ -149,7 +149,7 @@ namespace nap
 
 	void OSCSender::addEvent(OSCEventPtr oscEvent)
 	{
-        if(!mSocket)
+        if(mSocket!=nullptr)
             return;
 
 		mEventQueueDataSize += (oscEvent->getSize());

--- a/system_modules/naposc/src/oscsender.cpp
+++ b/system_modules/naposc/src/oscsender.cpp
@@ -54,7 +54,7 @@ namespace nap
 
 	void OSCSender::stop()
 	{
-        if(mSocket==nullptr)
+        if(mSocket!=nullptr)
             mSocket.reset(nullptr);
     }
 

--- a/system_modules/naposc/src/oscsender.h
+++ b/system_modules/naposc/src/oscsender.h
@@ -45,6 +45,7 @@ namespace nap
 		std::string mIPAddress = "127.0.0.1";	///< Property: 'IpAddress' target machine ip address
 		int mPort = 8000;			            ///< Property: 'Port' target machine port
 		int mBufferScale = 2;					///< Property: 'Scale' scale factor applied to OSC message buffer.
+		bool mAllowFailure = false;             ///< Property: 'AllowFailure' if true, the sender will not fail to init if it fails to create the UDPTransmitSocket on init
 
 
 		/**


### PR DESCRIPTION
This PR fixes a crash that can occur when UdpTransmitSocket constructor throws an exception. This can happen when there is no network connection. Also, it adds a `AllowFailure` property to the OSCSender that allows the OSCSender to initialize even when this happens.

Steps to test this PR

- Disconnect computer from any network, wireless or wired
- Changed to IP of the `OSCSender` resource in the OSCMidi demo to something that looks like a network address (like `168.122.33.44`)
- Run OSCMidi
- Observe application not initializing
- Open OSCMidi demo project json with Napkin
- Set `AllowFailure` property in the `OSCSender` resource to true
- Run OSCMidi
- Observe application initializing and log an error

