### PR TITLE
calendar items now emit an item changed signal whenever it's changed in someway

### DIFF
--- a/core/src/nap/datetime.h
+++ b/core/src/nap/datetime.h
@@ -345,6 +345,19 @@ namespace nap
 		 */
 		bool valid() const;
 
+		// Comparison operators
+		bool operator == (const Date &c) const
+		{
+			if (mDay == c.mDay && mMonth == c.mMonth && mYear == c.mYear)
+				return true;
+			return false;
+		}
+
+		bool operator != (const Date &c) const
+		{
+			return !(*this == c);
+		}
+
 		EMonth mMonth = EMonth::Unknown;			///< Property: 'Month' the month of the year
 		int mDay = 1;								///< Property: 'Day' the day of the month (1-31)
 		int mYear = 1970;							///< Property: 'Year' the year

--- a/system_modules/napcalendar/src/calendar.cpp
+++ b/system_modules/napcalendar/src/calendar.cpp
@@ -104,7 +104,9 @@ namespace nap
 		mItems.reserve(items.size());
 		for (const auto& item : items)
 		{
-			mItems.emplace_back(rtti::cloneObject(*item, mCore.getResourceManager()->getFactory()));
+			auto item_clone = rtti::cloneObject(*item, mCore.getResourceManager()->getFactory());
+			item_clone->changed.connect([this](const CalendarItem& changedItem) { itemChanged.trigger(changedItem); });
+			mItems.emplace_back(std::move(item_clone));
 		}
 		return true;
 	}
@@ -129,6 +131,7 @@ namespace nap
 
 	void CalendarInstance::addItem(std::unique_ptr<CalendarItem> item)
 	{
+		item->changed.connect([this](const CalendarItem& changedItem) { itemChanged.trigger(changedItem); });
 		mItems.emplace_back(std::move(item));
 		itemAdded.trigger(*mItems.back());
 	}
@@ -182,6 +185,7 @@ namespace nap
 				assert(false);
 				continue;
 			}
+			calendar_item->changed.connect([this](const CalendarItem& changedItem) { itemChanged.trigger(changedItem); });
 			mItems.emplace_back(std::move(calendar_item));
 		}
 		return true;

--- a/system_modules/napcalendar/src/calendar.h
+++ b/system_modules/napcalendar/src/calendar.h
@@ -248,6 +248,7 @@ namespace nap
 
 		Signal<const CalendarItem&> itemRemoved;	///< Called when an item is about to be removed
 		Signal<const CalendarItem&> itemAdded;		///< Called when an item is added
+		Signal<const CalendarItem&> itemChanged;	///< Called when an item is changed
 
 		OwnedCalendarItemList mItems;		///< List of unique calendar items
 		std::string mName;					///< Calendar name

--- a/system_modules/napcalendar/src/calendaritem.cpp
+++ b/system_modules/napcalendar/src/calendaritem.cpp
@@ -105,7 +105,12 @@ namespace nap
 
 	void CalendarItem::setTitle(const std::string& title)
 	{
-		mTitle = title;
+		// Check if title has changed, if so, signal the outside world
+		if (title!=mTitle)
+		{
+			mTitle = title;
+			changed(*this);
+		}
 	}
 
 
@@ -117,7 +122,12 @@ namespace nap
 
 	void CalendarItem::setDescription(const std::string& description)
 	{
-		mDescription = description;
+		// Check if description has changed, if so, signal the outside world
+		if (description != mDescription)
+		{
+			mDescription = description;
+			changed(*this);
+		}
 	}
 
 
@@ -129,12 +139,17 @@ namespace nap
 
 	bool CalendarItem::setPoint(const Point& point)
 	{
-		if (point.valid())
+		if (!point.valid())
+			return false;
+
+		// Signal the outside world this item has changed if the point has changed
+		if (mPoint != point)
 		{
 			mPoint = point;
-			return true;
+			changed(*this);
 		}
-		return false;
+
+		return true;
 	}
 
 
@@ -147,12 +162,20 @@ namespace nap
 	bool CalendarItem::setTime(const Time& time)
 	{
 		Time backup = mPoint.mTime;
-		mPoint.mTime = time;
+
 		if (!mPoint.valid())
 		{
 			mPoint.mTime = backup;
 			return false;
 		}
+
+		// Signal the outside world if this item has changed
+		if (mPoint.mTime != time)
+		{
+			mPoint.mTime = time;
+			changed(*this);
+		}
+
 		return true;
 	}
 
@@ -165,7 +188,11 @@ namespace nap
 
 	void CalendarItem::setDuration(const Time& duration)
 	{
-		mPoint.mDuration = duration;
+		if (duration!=mPoint.mDuration)
+		{
+			mPoint.mDuration = duration;
+			changed(*this);
+		}
 	}
 
 
@@ -195,9 +222,10 @@ namespace nap
 
 	bool WeeklyCalendarItem::setDay(EDay day)
 	{
-		if (day != EDay::Unknown)
+		if (day != EDay::Unknown && day != mDay)
 		{
 			mDay = day;
+			changed(*this);
 			return true;
 		}
 		return false;
@@ -297,6 +325,8 @@ namespace nap
 	{
 		if (!date.valid()) { return false; }
 		mDate = date;
+		if (date != mDate)
+			changed(*this);
 		return true;
 	}
 
@@ -338,6 +368,8 @@ namespace nap
 		if (day >= 1 && day <= 31)
 		{
 			mDay = day;
+			if (mDay!= day)
+				changed(*this);
 			return true;
 		}
 		return false;
@@ -409,6 +441,8 @@ namespace nap
 		if (day < 1 || day > 31 || month == EMonth::Unknown)
 			return false;
 		mDay = day; mMonth = month;
+		if (mDay != day || mMonth != month)
+			changed(*this);
 		return false;
 	}
 

--- a/system_modules/napcalendar/src/calendaritem.h
+++ b/system_modules/napcalendar/src/calendaritem.h
@@ -8,6 +8,7 @@
 #include <nap/resource.h>
 #include <nap/datetime.h>
 #include <nap/numeric.h>
+#include <nap/signalslot.h>
 
 namespace nap
 {
@@ -47,6 +48,19 @@ namespace nap
 			 * @return calendar point in time, hour and minute is negative if conversion fails
 			 */
 			static Time fromString(const std::string& time);
+
+			// Comparison operators
+			bool operator == (const Time &c) const
+			{
+				if (mHour == c.mHour && mMinute == c.mMinute)
+					return true;
+				return false;
+			}
+
+			bool operator != (const Time &c) const
+			{
+				return !(*this == c);
+			}
 		};
 
 		/**
@@ -60,6 +74,19 @@ namespace nap
 			Time mTime;							///< Property: 'Time' time of the event: hours (0-23) & minutes (0-59)
 			Time mDuration;						///< Property: 'Duration' length of event: hours (0-X) & minutes (0-59). Duration of 0 = never
 			bool valid() const;  				///< Returns if time is valid
+
+			// Comparison operators
+			bool operator == (const Point &c) const
+			{
+				if (mTime == c.mTime && mDuration == c.mDuration)
+					return true;
+				return false;
+			}
+
+			bool operator != (const Point &c) const
+			{
+				return !(*this == c);
+			}
 		};
 
 		// Default Constructor
@@ -141,6 +168,8 @@ namespace nap
 		 * @return item duration (hours, minutes)
 		 */
 		const Time& getDuration() const;
+
+		Signal<const CalendarItem&> changed;		///< Called when the item changes
 
 		std::string mTitle = "";			///< Property: 'Title' item title
 		Point		mPoint;					///< Property; 'Point' point in time together with duration


### PR DESCRIPTION
- calendar items now emit an item changed signal whenever it's changed in someway
- comparison operators added to both Date and Time structs for readable comparison
- the operational calendar emits and item changed signal whenever it's changed in someway

The following PR solves a long standing feature that I wanted to implement. Often in installations I need to perform a certain action when a user changes something in the operation calendar, either in the app or using the web client. This way I can listen to an update of the operation calendar when the user changes the calendar. Most of the times, I just want to save the operational calendar instantly then.