### PR TITLE
Update additive blend mode to multiply alpha

### DIFF
--- a/demos/audiovisualfft/app.json
+++ b/demos/audiovisualfft/app.json
@@ -5,7 +5,6 @@
     "Version": "0.1.0",
     "RequiredModules": [
         "napapp",
-        "napcameracontrol",
         "napparametergui",
         "napaudiovisualfft"
     ],

--- a/demos/audiovisualfft/build.sh
+++ b/demos/audiovisualfft/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+project_dir=$( cd "$(dirname -- "$0")" ; pwd -P )
+nap_root=$project_dir/../..
+. $nap_root/tools/buildsystem/common/sh_shared.sh
+configure_python $nap_root
+$python $nap_root/tools/buildsystem/common/build_app_by_dir.py $project_dir "$@"

--- a/system_modules/napaudio/module.json
+++ b/system_modules/napaudio/module.json
@@ -2,7 +2,6 @@
     "Type": "nap::ModuleInfo",
     "mID": "ModuleInfo",
     "RequiredModules": [
-        "napmath",
         "napscene"
     ],
     "WindowsDllSearchPaths": [

--- a/system_modules/napfft/module.json
+++ b/system_modules/napfft/module.json
@@ -2,8 +2,6 @@
     "Type": "nap::ModuleInfo",
     "mID": "ModuleInfo",
     "RequiredModules": [
-        "napmath",
-        "napscene",
         "napportaudio"
     ],
     "WindowsDllSearchPaths": []

--- a/system_modules/napportaudio/module.json
+++ b/system_modules/napportaudio/module.json
@@ -2,8 +2,6 @@
     "Type": "nap::ModuleInfo",
     "mID": "ModuleInfo",
     "RequiredModules": [
-        "napmath",
-        "napscene",
         "napaudio"
     ],
     "WindowsDllSearchPaths": [

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1022,8 +1022,8 @@ namespace nap
 			{
 				color_blend_attachment_state.blendEnable = VK_TRUE;
 				color_blend_attachment_state.srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-				color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
-				color_blend_attachment_state.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+				color_blend_attachment_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
+				color_blend_attachment_state.srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
 				color_blend_attachment_state.dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
 				break;
 			}


### PR DESCRIPTION
I think it would make more sense if the `Additive` blend function takes source alpha into account. This will resolve the same final color independent of ordering. Below an example where I'm rendering point sprites with alpha as a distance function in the fragment shader.

Original additive blending:
```
srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
```
![Screenshot from 2025-02-10 09-47-47](https://github.com/user-attachments/assets/0ac0174a-bf67-4867-a283-f51665a7a6c0)

Updated additive blending:
```
srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE;
dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
srcColorBlendFactor = VK_BLEND_FACTOR_SRC_ALPHA;
dstColorBlendFactor = VK_BLEND_FACTOR_ONE;
```
![Screenshot from 2025-02-10 09-45-56](https://github.com/user-attachments/assets/9547185d-3a0c-4411-9361-8031c012f78e)

This update could change the look of existing projects. Alternatively we could add this under the name `AdditiveBlend` or something like that.