### PR TITLE
Internal Textures, Links & Cleanup

### DIFF
--- a/demos/audiovisualfft/data/objects.json
+++ b/demos/audiovisualfft/data/objects.json
@@ -22,13 +22,13 @@
         {
             "Type": "nap::DepthRenderTexture2D",
             "mID": "DepthTexture",
-            "Usage": "Static",
             "Fill": false,
             "Width": 1920,
             "Height": 1080,
             "Format": "D16",
             "ColorSpace": "Linear",
-            "ClearValue": 1.0
+            "ClearValue": 1.0,
+            "Usage": "Internal"
         },
         {
             "Type": "nap::Entity",
@@ -39,7 +39,8 @@
                     "mID": "AudioPlayback",
                     "Buffer": "AudioFile",
                     "ChannelRouting": [
-                        0, 1
+                        0,
+                        1
                     ],
                     "Gain": 1.0,
                     "StereoPanning": 0.5,
@@ -501,6 +502,7 @@
                     },
                     "Intensity": 1.0,
                     "ShadowStrength": 1.0,
+                    "ShadowSpread": 2.0,
                     "Locator": {
                         "LineWidth": 1.0,
                         "GnomonSize": 1.0
@@ -1248,12 +1250,12 @@
                     0.0,
                     0.0
                 ]
-            }
+            },
+            "Clear": true
         },
         {
             "Type": "nap::RenderTexture2D",
             "mID": "ColorTexture",
-            "Usage": "Static",
             "Width": 1920,
             "Height": 1080,
             "Format": "RGBA8",
@@ -1265,12 +1267,12 @@
                     0.0,
                     0.0
                 ]
-            }
+            },
+            "Usage": "Internal"
         },
         {
             "Type": "nap::RenderTexture2D",
             "mID": "ColorTextureDOF",
-            "Usage": "Static",
             "Width": 1920,
             "Height": 1080,
             "Format": "RGBA8",
@@ -1282,12 +1284,12 @@
                     0.0,
                     0.0
                 ]
-            }
+            },
+            "Usage": "Internal"
         },
         {
             "Type": "nap::RenderTexture2D",
             "mID": "DummyTexture",
-            "Usage": "Static",
             "Width": 240,
             "Height": 135,
             "Format": "RGBA8",
@@ -1299,7 +1301,8 @@
                     0.0,
                     0.0
                 ]
-            }
+            },
+            "Usage": "Internal"
         },
         {
             "Type": "nap::RenderTextureCube",

--- a/demos/audiovisualfft/module/src/renderdofcomponent.cpp
+++ b/demos/audiovisualfft/module/src/renderdofcomponent.cpp
@@ -138,7 +138,7 @@ namespace nap
 		mIntermediateTexture.mWidth = mResource->mInputTarget->getBufferSize().x;
 		mIntermediateTexture.mHeight = mResource->mInputTarget->getBufferSize().y;
 		mIntermediateTexture.mColorFormat = mResource->mInputTarget->getColorTexture().mColorFormat;
-		mIntermediateTexture.mUsage = Texture::EUsage::Static;
+		mIntermediateTexture.mUsage = Texture::EUsage::Internal;
 		if (!mIntermediateTexture.init(errorState))
 		{
 			errorState.fail("%s: Failed to initialize internal render target", mIntermediateTexture.mID.c_str());

--- a/demos/audiovisualfft/module/src/renderdofcomponent.cpp
+++ b/demos/audiovisualfft/module/src/renderdofcomponent.cpp
@@ -138,7 +138,7 @@ namespace nap
 		mIntermediateTexture.mWidth = mResource->mInputTarget->getBufferSize().x;
 		mIntermediateTexture.mHeight = mResource->mInputTarget->getBufferSize().y;
 		mIntermediateTexture.mColorFormat = mResource->mInputTarget->getColorTexture().mColorFormat;
-		mIntermediateTexture.mUsage = Texture::EUsage::Internal;
+		mIntermediateTexture.mUsage = Texture2D::EUsage::Internal;
 		if (!mIntermediateTexture.init(errorState))
 		{
 			errorState.fail("%s: Failed to initialize internal render target", mIntermediateTexture.mID.c_str());

--- a/demos/computeflocking/data/computeflocking.json
+++ b/demos/computeflocking/data/computeflocking.json
@@ -1362,12 +1362,12 @@
                             0.0,
                             1.0
                         ]
-                    }
+                    },
+                    "Clear": true
                 },
                 {
                     "Type": "nap::RenderTexture2D",
                     "mID": "ColorTexture",
-                    "Usage": "Static",
                     "Width": 1920,
                     "Height": 1080,
                     "Format": "RGBA8",
@@ -1379,12 +1379,12 @@
                             0.0,
                             1.0
                         ]
-                    }
+                    },
+                    "Usage": "Internal"
                 },
                 {
                     "Type": "nap::RenderTexture2D",
                     "mID": "DummyRT",
-                    "Usage": "Static",
                     "Width": 1920,
                     "Height": 1080,
                     "Format": "RGBA8",
@@ -1396,7 +1396,8 @@
                             0.0,
                             0.0
                         ]
-                    }
+                    },
+                    "Usage": "Internal"
                 },
                 {
                     "Type": "nap::ConstantShader",
@@ -1641,7 +1642,6 @@
                         {
                             "Type": "nap::RenderTexture2D",
                             "mID": "ColorTextureFX",
-                            "Usage": "Static",
                             "Width": 1920,
                             "Height": 1080,
                             "Format": "RGBA8",
@@ -1653,7 +1653,8 @@
                                     0.0,
                                     1.0
                                 ]
-                            }
+                            },
+                            "Usage": "Internal"
                         },
                         {
                             "Type": "nap::Material",

--- a/demos/videomodulation/data/videomodulation.json
+++ b/demos/videomodulation/data/videomodulation.json
@@ -631,7 +631,7 @@
                         {
                             "Type": "nap::RenderTexture2D",
                             "mID": "VideoColorTexture",
-                            "Usage": "Static",
+                            "Usage": "Internal",
                             "Width": 1920,
                             "Height": 1080,
                             "Format": "RGBA8",
@@ -648,7 +648,7 @@
                         {
                             "Type": "nap::RenderTexture2D",
                             "mID": "OutputTexture",
-                            "Usage": "Static",
+                            "Usage": "Internal",
                             "Width": 1920,
                             "Height": 1080,
                             "Format": "RGBA8",

--- a/system_modules/napimgui/src/imguiicon.cpp
+++ b/system_modules/napimgui/src/imguiicon.cpp
@@ -94,7 +94,7 @@ namespace nap
 
 		// Create 2D texture
 		int lvl = utility::computeMipLevel(descriptor);
-		return mTexture.init(descriptor, Texture::EUsage::Static, lvl, file_buffer.getData(), 0, error);
+		return mTexture.init(descriptor, Texture2D::EUsage::Static, lvl, file_buffer.getData(), 0, error);
 	}
 
 

--- a/system_modules/napimgui/src/imguiicon.cpp
+++ b/system_modules/napimgui/src/imguiicon.cpp
@@ -75,6 +75,7 @@ namespace nap
 
 		// Extract name
 		mName = utility::stripFileExtension(utility::getFileName(mImagePath));
+		mTexture.mID = mName;
 
 		// Load bitmap into memory
 		BitmapFileBuffer file_buffer;
@@ -87,12 +88,12 @@ namespace nap
 			return false;
 
 		// Get max supported LOD
-		int lvl = 1;
-		if (!utility::computeMipLevel(descriptor, mTexture.getRenderService().getPhysicalDevice(), lvl, error))
-			return false;
+		if (!error.check(mTexture.getRenderService().getMipSupport(descriptor),
+			"%s: hardware mipmap generation not supported", mID.c_str()))
+			return  false;
 
 		// Create 2D texture
-		mTexture.mID = mName;
+		int lvl = utility::computeMipLevel(descriptor);
 		return mTexture.init(descriptor, Texture::EUsage::Static, lvl, file_buffer.getData(), 0, error);
 	}
 

--- a/system_modules/napimgui/src/imguiicon.cpp
+++ b/system_modules/napimgui/src/imguiicon.cpp
@@ -12,6 +12,7 @@
 #include <FreeImage.h>
 #include <bitmapfilebuffer.h>
 #include <copyimagedata.h>
+#include <renderservice.h>
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::Icon, "Icon that can be displayed in a GUI")
 	RTTI_CONSTRUCTOR(nap::IMGuiService&)
@@ -85,9 +86,14 @@ namespace nap
 		if (mInvert && !invert(file_buffer, error))
 			return false;
 
+		// Get max supported LOD
+		int lvl = 1;
+		if (!utility::computeMipLevel(descriptor, mTexture.getRenderService().getPhysicalDevice(), lvl, error))
+			return false;
+
 		// Create 2D texture
 		mTexture.mID = mName;
-		return mTexture.init(descriptor, Texture::EUsage::Static, true, file_buffer.getData(), 0, error);
+		return mTexture.init(descriptor, Texture::EUsage::Static, lvl, file_buffer.getData(), 0, error);
 	}
 
 

--- a/system_modules/napimgui/src/imguiicon.cpp
+++ b/system_modules/napimgui/src/imguiicon.cpp
@@ -87,7 +87,7 @@ namespace nap
 
 		// Create 2D texture
 		mTexture.mID = mName;
-		return mTexture.init(descriptor, true, file_buffer.getData(), 0, error);
+		return mTexture.init(descriptor, Texture::EUsage::Static, true, file_buffer.getData(), 0, error);
 	}
 
 

--- a/system_modules/napimgui/src/imguiicon.cpp
+++ b/system_modules/napimgui/src/imguiicon.cpp
@@ -75,7 +75,7 @@ namespace nap
 
 		// Extract name
 		mName = utility::stripFileExtension(utility::getFileName(mImagePath));
-		mTexture.mID = mName;
+		mTexture.mID = mName + "_icon";
 
 		// Load bitmap into memory
 		BitmapFileBuffer file_buffer;

--- a/system_modules/naprender/src/depthrendertarget.cpp
+++ b/system_modules/naprender/src/depthrendertarget.cpp
@@ -27,7 +27,8 @@ namespace nap
 	//////////////////////////////////////////////////////////////////////////
 
 	DepthRenderTarget::DepthRenderTarget(Core& core) :
-		mRenderService(core.getService<RenderService>())
+		mRenderService(core.getService<RenderService>()),
+		mTextureTargetLink(*this)
 	{}
 
 
@@ -127,10 +128,9 @@ namespace nap
 
 	void DepthRenderTarget::endRendering()
 	{
+		// End render pass and sync layout
 		vkCmdEndRenderPass(mRenderService->getCurrentCommandBuffer());
-
-        // Sync image data with render pass final layout
-        mDepthTexture->syncLayout();
+		mTextureTargetLink.sync(*mDepthTexture);
 	}
 
 

--- a/system_modules/naprender/src/depthrendertarget.h
+++ b/system_modules/naprender/src/depthrendertarget.h
@@ -154,6 +154,11 @@ namespace nap
 		virtual VkFormat getDepthFormat() const override;
 
 		/**
+		 * @return layout of the depth texture when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override					{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; }
+
+		/**
 		 * @return the texture that holds the result of the render pass.
 		 */
 		DepthRenderTexture2D& getDepthTexture();

--- a/system_modules/naprender/src/depthrendertarget.h
+++ b/system_modules/naprender/src/depthrendertarget.h
@@ -6,6 +6,7 @@
 
 // Local Includes
 #include "irendertarget.h"
+#include "texturelink.h"
 
 // External Includes
 #include <nap/resource.h>
@@ -164,16 +165,17 @@ namespace nap
 		DepthRenderTexture2D& getDepthTexture();
 
 	public:
-		float								mClearValue = 1.0f;									///< Property: 'ClearValue' value selection used for clearing the render target
-		bool								mSampleShading = true;								///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost.
-		ERasterizationSamples				mRequestedSamples = ERasterizationSamples::One;		///< Property: 'Samples' The number of samples used during Rasterization. For better results turn on 'SampleShading'.
-		ResourcePtr<DepthRenderTexture2D>	mDepthTexture;										///< Property: 'DepthTexture' depth texture to render to
+		float									mClearValue = 1.0f;									///< Property: 'ClearValue' value selection used for clearing the render target
+		bool									mSampleShading = true;								///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost.
+		ERasterizationSamples					mRequestedSamples = ERasterizationSamples::One;		///< Property: 'Samples' The number of samples used during Rasterization. For better results turn on 'SampleShading'.
+		ResourcePtr<DepthRenderTexture2D>		mDepthTexture;										///< Property: 'DepthTexture' depth texture to render to
 
 	private:
-		RenderService*						mRenderService;
-		VkFramebuffer						mFramebuffer = VK_NULL_HANDLE;
-		VkRenderPass						mRenderPass = VK_NULL_HANDLE;
-		VkSampleCountFlagBits				mRasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-		RGBAColorFloat						mClearColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+		RenderService*							mRenderService;
+		VkFramebuffer							mFramebuffer = VK_NULL_HANDLE;
+		VkRenderPass							mRenderPass = VK_NULL_HANDLE;
+		VkSampleCountFlagBits					mRasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+		RGBAColorFloat							mClearColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+		Texture2DTargetLink						mTextureTargetLink;
 	};
 }

--- a/system_modules/naprender/src/imagefromfile.cpp
+++ b/system_modules/naprender/src/imagefromfile.cpp
@@ -37,15 +37,13 @@ namespace nap
 		if (!getBitmap().initFromFile(mImagePath, errorState))
 			return false;
 
-		// Compute max lod level
-		int lvl = 1;
-		if (mGenerateLods && !utility::computeMipLevel(getBitmap().mSurfaceDescriptor, mRenderService.getPhysicalDevice(), lvl, errorState))
-		{
-			errorState.fail("Consider disabling mipmap generation");
+		// Ensure hardware mip-mapping is supported
+		if(!errorState.check(!mGenerateLods || mRenderService.getMipSupport(getBitmap().mSurfaceDescriptor),
+			"%s: hardware mipmap generation not supported, consider disabling 'GenerateLods'", mID.c_str()))
 			return false;
-		}
 
-		// Initialize texture
+		// Initialize
+		int lvl = mGenerateLods ? utility::computeMipLevel(getBitmap().mSurfaceDescriptor) : 1;
 		return Texture2D::init(getBitmap().mSurfaceDescriptor, mUsage, lvl, getBitmap().getData(), 0, errorState);
 	}
 }

--- a/system_modules/naprender/src/imagefromfile.cpp
+++ b/system_modules/naprender/src/imagefromfile.cpp
@@ -11,6 +11,7 @@
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::ImageFromFile, "2D image that is loaded from disk and uploaded to the GPU. Holds the CPU (bitmap) and GPU (texture) data")
 	RTTI_CONSTRUCTOR(nap::Core&)
+	RTTI_PROPERTY("Usage",					&nap::ImageFromFile::mUsage,			nap::rtti::EPropertyMetaData::Default, "How the texture is used at runtime (static, updated etc..)")
 	RTTI_PROPERTY_FILELINK("ImagePath",		&nap::ImageFromFile::mImagePath, 		nap::rtti::EPropertyMetaData::Required, nap::rtti::EPropertyFileType::Image, "Path to the image on disk")
 	RTTI_PROPERTY("GenerateLods",			&nap::ImageFromFile::mGenerateLods,		nap::rtti::EPropertyMetaData::Default, "If lower levels of detail (LODs) are auto-generated for the image")
 RTTI_END_CLASS
@@ -36,6 +37,6 @@ namespace nap
 			return false;
 
 		// Create 2D texture
-		return Texture2D::init(getBitmap().mSurfaceDescriptor, mGenerateLods, getBitmap().getData(), 0, errorState);
+		return Texture2D::init(getBitmap().mSurfaceDescriptor, mUsage, mGenerateLods, getBitmap().getData(), 0, errorState);
 	}
 }

--- a/system_modules/naprender/src/imagefromfile.h
+++ b/system_modules/naprender/src/imagefromfile.h
@@ -42,5 +42,6 @@ namespace nap
 	public:
 		std::string				mImagePath;								///< Property: 'ImagePath' Path to the image on disk to load
 		bool					mGenerateLods = true;					///< Property: 'GenerateLods' If LODs are generated for this image
+		EUsage					mUsage = EUsage::Static;				///< Property: 'Usage' GPU Texture usage
 	};
 }

--- a/system_modules/naprender/src/irendertarget.h
+++ b/system_modules/naprender/src/irendertarget.h
@@ -75,5 +75,10 @@ namespace nap
 		 * @return if sample based shading is enabled
 		 */
 		virtual bool getSampleShadingEnabled() const = 0;
+
+		/**
+		 * @return image layout when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const = 0;
 	};
 }

--- a/system_modules/naprender/src/renderableglyph.cpp
+++ b/system_modules/naprender/src/renderableglyph.cpp
@@ -96,7 +96,7 @@ namespace nap
 
 		// Initialize texture
 		int lvl = generateMipmaps ? utility::computeMipLevel(settings) : 1;
-		if (!mTexture->init(settings, Texture::EUsage::Static, lvl, bitmap_glyph->bitmap.buffer, 0, errorCode))
+		if (!mTexture->init(settings, Texture2D::EUsage::Static, lvl, bitmap_glyph->bitmap.buffer, 0, errorCode))
 			return false;
 
 		// Clean up bitmap data

--- a/system_modules/naprender/src/renderableglyph.cpp
+++ b/system_modules/naprender/src/renderableglyph.cpp
@@ -89,12 +89,13 @@ namespace nap
 		settings.mDataType = ESurfaceDataType::BYTE;
 		settings.mChannels = ESurfaceChannels::R;
 
-		// Get lod if mip-map generation is turned on
-		int lvl = 1;
-		if (generateMipmaps && !utility::computeMipLevel(settings, mTexture->getRenderService().getPhysicalDevice(), lvl, errorCode))
-			return false;
+		// Get max supported LOD
+		if (!errorCode.check(!generateMipmaps || mTexture->getRenderService().getMipSupport(settings),
+			"hardware mipmap generation not supported for glyphs"))
+			return  false;
 
 		// Initialize texture
+		int lvl = generateMipmaps ? utility::computeMipLevel(settings) : 1;
 		if (!mTexture->init(settings, Texture::EUsage::Static, lvl, bitmap_glyph->bitmap.buffer, 0, errorCode))
 			return false;
 

--- a/system_modules/naprender/src/renderableglyph.cpp
+++ b/system_modules/naprender/src/renderableglyph.cpp
@@ -82,14 +82,20 @@ namespace nap
 		// Create texture and get parameters
 		mTexture = std::make_unique<Texture2D>(*mCore);
 
-		// Initialize texture
+		// Create glyph texture description
 		SurfaceDescriptor settings;
 		settings.mWidth  = mSize.x;
 		settings.mHeight = mSize.y;
 		settings.mDataType = ESurfaceDataType::BYTE;
 		settings.mChannels = ESurfaceChannels::R;
-		
-		if (!mTexture->init(settings, Texture::EUsage::Static, generateMipmaps, bitmap_glyph->bitmap.buffer, 0, errorCode))
+
+		// Get lod if mip-map generation is turned on
+		int lvl = 1;
+		if (generateMipmaps && !utility::computeMipLevel(settings, mTexture->getRenderService().getPhysicalDevice(), lvl, errorCode))
+			return false;
+
+		// Initialize texture
+		if (!mTexture->init(settings, Texture::EUsage::Static, lvl, bitmap_glyph->bitmap.buffer, 0, errorCode))
 			return false;
 
 		// Clean up bitmap data

--- a/system_modules/naprender/src/renderableglyph.cpp
+++ b/system_modules/naprender/src/renderableglyph.cpp
@@ -89,7 +89,7 @@ namespace nap
 		settings.mDataType = ESurfaceDataType::BYTE;
 		settings.mChannels = ESurfaceChannels::R;
 		
-		if (!mTexture->init(settings, generateMipmaps, bitmap_glyph->bitmap.buffer, 0, errorCode))
+		if (!mTexture->init(settings, Texture::EUsage::Static, generateMipmaps, bitmap_glyph->bitmap.buffer, 0, errorCode))
 			return false;
 
 		// Clean up bitmap data

--- a/system_modules/naprender/src/renderbloomcomponent.cpp
+++ b/system_modules/naprender/src/renderbloomcomponent.cpp
@@ -91,7 +91,6 @@ namespace nap
 				tex->mWidth = resource->mInputTexture->getWidth() / math::power<int>(2, pass_idx+1);
 				tex->mHeight = resource->mInputTexture->getHeight() / math::power<int>(2, pass_idx+1);
 				tex->mColorFormat = resource->mInputTexture->mColorFormat;
-				tex->mUsage = Texture::EUsage::Static;
 				if (!tex->init(errorState))
 				{
 					errorState.fail("%s: Failed to initialize internal render texture", tex->mID.c_str());

--- a/system_modules/naprender/src/renderbloomcomponent.cpp
+++ b/system_modules/naprender/src/renderbloomcomponent.cpp
@@ -103,7 +103,6 @@ namespace nap
 				target->mClearColor = resource->mInputTexture->mClearColor;
 				target->mSampleShading = false;
 				target->mRequestedSamples = ERasterizationSamples::One;
-
 				if (!target->init(errorState))
 				{
 					errorState.fail("%s: Failed to initialize internal render target", target->mID.c_str());

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -2872,6 +2872,15 @@ namespace nap
 	}
 
 
+	bool RenderService::getMipSupport(const SurfaceDescriptor& descriptor) const
+	{
+		// Get format properties
+		VkFormatProperties properties;
+		vkGetPhysicalDeviceFormatProperties(mPhysicalDevice.getHandle(), utility::getTextureFormat(descriptor), &properties);
+		return (properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) > 0;
+	}
+
+
 	RenderService::UniqueMaterial::UniqueMaterial(std::unique_ptr<Shader> shader, std::unique_ptr<Material> material) :
 		mShader(std::move(shader)), mMaterial(std::move(material))
 	{ }

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1657,7 +1657,7 @@ namespace nap
 		SurfaceDescriptor settings = { 1, 1, ESurfaceDataType::BYTE, ESurfaceChannels::RGBA };
 		mEmptyTexture2D = std::make_unique<Texture2D>(getCore());
 		mEmptyTexture2D->mID = utility::stringFormat("%s_EmptyTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mEmptyTexture2D->init(settings, Texture::EUsage::Internal, 1, glm::zero<glm::vec4>(), 0, errorState))
+		if (!mEmptyTexture2D->init(settings, Texture2D::EUsage::Internal, 1, glm::zero<glm::vec4>(), 0, errorState))
 			return false;
 
 		mEmptyTextureCube = std::make_unique<TextureCube>(getCore());
@@ -1667,7 +1667,7 @@ namespace nap
 
 		mErrorTexture2D = std::make_unique<Texture2D>(getCore());
 		mErrorTexture2D->mID = utility::stringFormat("%s_ErrorTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mErrorTexture2D->init(settings, Texture::EUsage::Internal, 1, mErrorColor.toVec4(), 0, errorState))
+		if (!mErrorTexture2D->init(settings, Texture2D::EUsage::Internal, 1, mErrorColor.toVec4(), 0, errorState))
 			return false;
 
 		mErrorTextureCube = std::make_unique<TextureCube>(getCore());

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1662,7 +1662,7 @@ namespace nap
 
 		mEmptyTextureCube = std::make_unique<TextureCube>(getCore());
 		mEmptyTextureCube->mID = utility::stringFormat("%s_EmptyTextureCube_%s", RTTI_OF(TextureCube).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mEmptyTextureCube->init(settings, false, glm::zero<glm::vec4>(), 0, errorState))
+		if (!mEmptyTextureCube->init(settings, 1, glm::zero<glm::vec4>(), 0, errorState))
 			return false;
 
 		mErrorTexture2D = std::make_unique<Texture2D>(getCore());
@@ -1672,7 +1672,7 @@ namespace nap
 
 		mErrorTextureCube = std::make_unique<TextureCube>(getCore());
 		mErrorTextureCube->mID = utility::stringFormat("%s_ErrorTextureCube_%s", RTTI_OF(TextureCube).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mErrorTextureCube->init(settings, false, mErrorColor.toVec4(), 0, errorState))
+		if (!mErrorTextureCube->init(settings, 1, mErrorColor.toVec4(), 0, errorState))
 			return false;
 
 		return true;

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1657,7 +1657,7 @@ namespace nap
 		SurfaceDescriptor settings = { 1, 1, ESurfaceDataType::BYTE, ESurfaceChannels::RGBA };
 		mEmptyTexture2D = std::make_unique<Texture2D>(getCore());
 		mEmptyTexture2D->mID = utility::stringFormat("%s_EmptyTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mEmptyTexture2D->init(settings, Texture::EUsage::Internal, false, glm::zero<glm::vec4>(), 0, errorState))
+		if (!mEmptyTexture2D->init(settings, Texture::EUsage::Internal, 1, glm::zero<glm::vec4>(), 0, errorState))
 			return false;
 
 		mEmptyTextureCube = std::make_unique<TextureCube>(getCore());
@@ -1667,7 +1667,7 @@ namespace nap
 
 		mErrorTexture2D = std::make_unique<Texture2D>(getCore());
 		mErrorTexture2D->mID = utility::stringFormat("%s_ErrorTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mErrorTexture2D->init(settings, Texture::EUsage::Internal, false, mErrorColor.toVec4(), 0, errorState))
+		if (!mErrorTexture2D->init(settings, Texture::EUsage::Internal, 1, mErrorColor.toVec4(), 0, errorState))
 			return false;
 
 		mErrorTextureCube = std::make_unique<TextureCube>(getCore());

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1657,7 +1657,7 @@ namespace nap
 		SurfaceDescriptor settings = { 1, 1, ESurfaceDataType::BYTE, ESurfaceChannels::RGBA };
 		mEmptyTexture2D = std::make_unique<Texture2D>(getCore());
 		mEmptyTexture2D->mID = utility::stringFormat("%s_EmptyTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mEmptyTexture2D->init(settings, false, glm::zero<glm::vec4>(), 0, errorState))
+		if (!mEmptyTexture2D->init(settings, Texture::EUsage::Internal, false, glm::zero<glm::vec4>(), 0, errorState))
 			return false;
 
 		mEmptyTextureCube = std::make_unique<TextureCube>(getCore());
@@ -1667,7 +1667,7 @@ namespace nap
 
 		mErrorTexture2D = std::make_unique<Texture2D>(getCore());
 		mErrorTexture2D->mID = utility::stringFormat("%s_ErrorTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mErrorTexture2D->init(settings, false, mErrorColor.toVec4(), 0, errorState))
+		if (!mErrorTexture2D->init(settings, Texture::EUsage::Internal, false, mErrorColor.toVec4(), 0, errorState))
 			return false;
 
 		mErrorTextureCube = std::make_unique<TextureCube>(getCore());

--- a/system_modules/naprender/src/renderservice.cpp
+++ b/system_modules/naprender/src/renderservice.cpp
@@ -1657,7 +1657,7 @@ namespace nap
 		SurfaceDescriptor settings = { 1, 1, ESurfaceDataType::BYTE, ESurfaceChannels::RGBA };
 		mEmptyTexture2D = std::make_unique<Texture2D>(getCore());
 		mEmptyTexture2D->mID = utility::stringFormat("%s_EmptyTexture2D_%s", RTTI_OF(Texture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
-		if (!mEmptyTexture2D->init(settings, false, 0, errorState))
+		if (!mEmptyTexture2D->init(settings, false, glm::zero<glm::vec4>(), 0, errorState))
 			return false;
 
 		mEmptyTextureCube = std::make_unique<TextureCube>(getCore());

--- a/system_modules/naprender/src/renderservice.h
+++ b/system_modules/naprender/src/renderservice.h
@@ -846,6 +846,13 @@ namespace nap
 		bool getLargePointsSupported() const										{ return mLargePointsSupported; }
 
 		/**
+		 * Returns if hardware down-sampling is supported for the given texture type
+		 * @param descriptor texture description
+		 * @return if map-map generation is supported for the given texture type
+		 */
+		bool getMipSupport(const SurfaceDescriptor& descriptor) const;
+
+		/**
 		 * Configurable setting.
 		 * When enabled fonts and general scaling is adjusted for high dpi monitors.
 		 * @return if high dpi mode is enabled

--- a/system_modules/naprender/src/rendertarget.cpp
+++ b/system_modules/naprender/src/rendertarget.cpp
@@ -108,12 +108,12 @@ namespace nap
 			if (!errorState.check(mRasterizationSamples == VK_SAMPLE_COUNT_1_BIT, "Depth resolve attachments are not supported. Set the sample count to one if a depth texture resource is desired."))
 				return false;
 
-			if (!createRenderPass(mRenderService->getDevice(), mColorTexture->getFormat(), mDepthTexture->getFormat(), mRasterizationSamples, mColorTexture->getTargetLayout(), mClear, true, mRenderPass, errorState))
+			if (!createRenderPass(mRenderService->getDevice(), mColorTexture->getFormat(), mDepthTexture->getFormat(), mRasterizationSamples, getFinalLayout(), mClear, true, mRenderPass, errorState))
 				return false;
 		}
 		else
 		{
-			if (!createRenderPass(mRenderService->getDevice(), mColorTexture->getFormat(), mRenderService->getDepthFormat(), mRasterizationSamples, mColorTexture->getTargetLayout(), mClear, false, mRenderPass, errorState))
+			if (!createRenderPass(mRenderService->getDevice(), mColorTexture->getFormat(), mRenderService->getDepthFormat(), mRasterizationSamples, getFinalLayout(), mClear, false, mRenderPass, errorState))
 				return false;
 		}
 

--- a/system_modules/naprender/src/rendertarget.h
+++ b/system_modules/naprender/src/rendertarget.h
@@ -7,6 +7,7 @@
 // Local Includes
 #include "irendertarget.h"
 #include "rendertexture2d.h"
+#include "texturelink.h"
 
 // External Includes
 #include <nap/resource.h>
@@ -140,7 +141,7 @@ namespace nap
 		/**
 		 * @return whether this render target writes to a specified depth texture resource
 		 */
-		bool hasDepthTexture() const											{ return mHasDepthTexture; }
+		bool hasDepthTexture() const											{ return mDepthTexture != nullptr; }
 
 		/**
 		 * @return the texture that holds the result of the render pass.
@@ -194,6 +195,6 @@ namespace nap
 		VkSampleCountFlagBits				mRasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 		ImageData							mDepthImage;
 		ImageData							mColorImage;
-		bool								mHasDepthTexture = false;
+		Texture2DTargetLink					mTextureLink;
 	};
 }

--- a/system_modules/naprender/src/rendertarget.h
+++ b/system_modules/naprender/src/rendertarget.h
@@ -174,6 +174,11 @@ namespace nap
 		 */
 		virtual bool getSampleShadingEnabled() const override;
 
+		/**
+		 * @return layout of the texture when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override									{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; }
+
 	public:	
 		bool								mSampleShading = true;								///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost.
 		RGBAColorFloat						mClearColor = { 0.0f, 0.0f, 0.0f, 0.0f };			///< Property: 'ClearColor' color selection used for clearing the render target

--- a/system_modules/naprender/src/rendertexture2d.cpp
+++ b/system_modules/naprender/src/rendertexture2d.cpp
@@ -121,7 +121,7 @@ namespace nap
 
     void RenderTexture2D::syncLayout()
     {
-        getHandle().mCurrentLayout = getTargetLayout();
+        //getHandle().mCurrentLayout = getTargetLayout();
     }
 
 
@@ -170,6 +170,6 @@ namespace nap
 
     void DepthRenderTexture2D::syncLayout()
     {
-        getHandle().mCurrentLayout = getTargetLayout();
+        //getHandle().mCurrentLayout = getTargetLayout();
     }
 }

--- a/system_modules/naprender/src/rendertexture2d.cpp
+++ b/system_modules/naprender/src/rendertexture2d.cpp
@@ -118,12 +118,6 @@ namespace nap
 	}
 
 
-    void RenderTexture2D::syncLayout()
-    {
-        //getHandle().mCurrentLayout = getTargetLayout();
-    }
-
-
 	//////////////////////////////////////////////////////////////////////////
 	// DepthRenderTexture2D
 	//////////////////////////////////////////////////////////////////////////
@@ -162,9 +156,4 @@ namespace nap
 			}
 		}
 	}
-
-    void DepthRenderTexture2D::syncLayout()
-    {
-        //getHandle().mCurrentLayout = getTargetLayout();
-    }
 }

--- a/system_modules/naprender/src/rendertexture2d.cpp
+++ b/system_modules/naprender/src/rendertexture2d.cpp
@@ -114,7 +114,7 @@ namespace nap
 		}
 
 		// Create render texture
-		return Texture2D::init(settings, mUsage, false, mClearColor.toVec4(), VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, errorState);
+		return Texture2D::init(settings, mUsage, 1, mClearColor.toVec4(), VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, errorState);
 	}
 
 
@@ -148,14 +148,12 @@ namespace nap
 			case DepthRenderTexture2D::EDepthFormat::D16:
 			{
 				settings.mDataType = ESurfaceDataType::USHORT;
-				return Texture2D::init(settings, mUsage, false,
-					clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
+				return Texture2D::init(settings, mUsage, 1, clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
 			}
 			case DepthRenderTexture2D::EDepthFormat::D32:
 			{
 				settings.mDataType = ESurfaceDataType::FLOAT;
-				return Texture2D::init(settings, mUsage, false,
-					clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
+				return Texture2D::init(settings, mUsage, 1, clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
 			}
 			default:
 			{

--- a/system_modules/naprender/src/rendertexture2d.cpp
+++ b/system_modules/naprender/src/rendertexture2d.cpp
@@ -23,6 +23,7 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::RenderTexture2D, "Holds the color o
 	RTTI_PROPERTY("Format",		&nap::RenderTexture2D::mColorFormat,	nap::rtti::EPropertyMetaData::Required, "Texture color format")
 	RTTI_PROPERTY("ColorSpace", &nap::RenderTexture2D::mColorSpace,		nap::rtti::EPropertyMetaData::Default,	"Texture color space")
 	RTTI_PROPERTY("ClearColor", &nap::RenderTexture2D::mClearColor,		nap::rtti::EPropertyMetaData::Default,	"Initial clear color")
+	RTTI_PROPERTY("Usage",		&nap::RenderTexture2D::mUsage,			nap::rtti::EPropertyMetaData::Default,	"How the texture is used at runtime (internal, updated etc..)")
 RTTI_END_CLASS
 
 RTTI_BEGIN_ENUM(nap::DepthRenderTexture2D::EDepthFormat)
@@ -38,6 +39,7 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::DepthRenderTexture2D, "Holds the de
 	RTTI_PROPERTY("Format",		&nap::DepthRenderTexture2D::mDepthFormat,	nap::rtti::EPropertyMetaData::Required, "Texture depth format")
 	RTTI_PROPERTY("ColorSpace", &nap::DepthRenderTexture2D::mColorSpace,	nap::rtti::EPropertyMetaData::Default,	"Texture color space")
 	RTTI_PROPERTY("ClearValue", &nap::DepthRenderTexture2D::mClearValue,	nap::rtti::EPropertyMetaData::Default,	"Initial clear value")
+	RTTI_PROPERTY("Usage",		&nap::DepthRenderTexture2D::mUsage,			nap::rtti::EPropertyMetaData::Default,	"How the texture is used at runtime (internal, updated etc..)")
 RTTI_END_CLASS
 
 
@@ -111,11 +113,8 @@ namespace nap
 			}
 		}
 
-		// Ensure texture can be used as an attachment for a render pass
-		VkImageUsageFlags required_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
 		// Create render texture
-		return Texture2D::init(settings, false, mClearColor.toVec4(), required_flags, errorState);
+		return Texture2D::init(settings, mUsage, false, mClearColor.toVec4(), VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, errorState);
 	}
 
 
@@ -142,29 +141,27 @@ namespace nap
 		settings.mColorSpace = mColorSpace;
 		settings.mChannels = ESurfaceChannels::D;
 
-		const glm::vec4 clear_color = { mClearValue, mClearValue, mClearValue, mClearValue };
-
-		// Ensure texture can be used as an attachment for a render pass
-		VkImageUsageFlags required_flags = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-
 		// Initialize based on selected format
+		const glm::vec4 clear_color = { mClearValue, mClearValue, mClearValue, mClearValue };
 		switch (mDepthFormat)
 		{
-		case DepthRenderTexture2D::EDepthFormat::D16:
-		{
-			settings.mDataType = ESurfaceDataType::USHORT;
-			return Texture2D::init(settings, false, clear_color, required_flags, errorState);
-		}
-		case DepthRenderTexture2D::EDepthFormat::D32:
-		{
-			settings.mDataType = ESurfaceDataType::FLOAT;
-			return Texture2D::init(settings, false, clear_color, required_flags, errorState);
-		}
-		default:
-		{
-			errorState.fail("Unsupported format");
-			return false;
-		}
+			case DepthRenderTexture2D::EDepthFormat::D16:
+			{
+				settings.mDataType = ESurfaceDataType::USHORT;
+				return Texture2D::init(settings, mUsage, false,
+					clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
+			}
+			case DepthRenderTexture2D::EDepthFormat::D32:
+			{
+				settings.mDataType = ESurfaceDataType::FLOAT;
+				return Texture2D::init(settings, mUsage, false,
+					clear_color, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, errorState);
+			}
+			default:
+			{
+				errorState.fail("Unsupported format");
+				return false;
+			}
 		}
 	}
 

--- a/system_modules/naprender/src/rendertexture2d.h
+++ b/system_modules/naprender/src/rendertexture2d.h
@@ -60,6 +60,7 @@ namespace nap
 		EColorSpace			mColorSpace = EColorSpace::Linear;				///< Property: 'ColorSpace' texture color space
 		EFormat				mColorFormat = EFormat::RGBA8;					///< Property: 'ColorFormat' color texture format
 		RGBAColorFloat		mClearColor	= { 0.0f, 0.0f, 0.0f, 0.0f };		///< Property: 'ClearColor' color selection used for clearing the texture
+		EUsage				mUsage = EUsage::Internal;						///< Property: 'Usage' GPU Texture usage
 	};
 
 
@@ -101,5 +102,6 @@ namespace nap
 		EDepthFormat		mDepthFormat = EDepthFormat::D16;				///< Property: 'DepthFormat' depth texture format
 		float				mClearValue = 1.0f;								///< Property: 'ClearValue' value selection used for clearing the texture
 		bool				mFill = false;									///< Property: 'Fill' if the texture is initialized to black when usage is static
+		EUsage				mUsage = EUsage::Internal;						///< Property: 'Usage' GPU Texture usage
 	};
 }

--- a/system_modules/naprender/src/rendertexture2d.h
+++ b/system_modules/naprender/src/rendertexture2d.h
@@ -50,11 +50,6 @@ namespace nap
 		 */
 		virtual bool init(utility::ErrorState& errorState) override;
 
-        /**
-         * Updates image layout to the target layout after a render pass.
-         */
-        void syncLayout();
-
 		int					mWidth = 0;										///< Property: 'Width' width of the texture in texels
 		int					mHeight = 0;									///< Property: 'Height' of the texture in texels
 		EColorSpace			mColorSpace = EColorSpace::Linear;				///< Property: 'ColorSpace' texture color space
@@ -90,11 +85,6 @@ namespace nap
 		 * @return if the texture was created successfully
 		 */
 		virtual bool init(utility::ErrorState& errorState) override;
-
-        /**
-         * Updates image layout to the target layout after a render pass.
-         */
-        void syncLayout();
 
 		int					mWidth = 0;										///< Property: 'Width' width of the texture in texels
 		int					mHeight = 0;									///< Property: 'Height' of the texture in texels

--- a/system_modules/naprender/src/rendertexturecube.cpp
+++ b/system_modules/naprender/src/rendertexturecube.cpp
@@ -8,13 +8,13 @@
 
 
 RTTI_BEGIN_ENUM(nap::RenderTextureCube::EFormat)
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA8, "RGBA8"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::BGRA8, "BGRA8"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R8, "R8"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA16, "RGBA16"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R16, "R16"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA32, "RGBA32"),
-	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R32, "R32")
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA8,		"RGBA8"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::BGRA8,		"BGRA8"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R8,		"R8"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA16,	"RGBA16"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R16,		"R16"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::RGBA32,	"RGBA32"),
+	RTTI_ENUM_VALUE(nap::RenderTextureCube::EFormat::R32,		"R32")
 RTTI_END_ENUM
 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::RenderTextureCube, "Cubemap GPU color texture ")
@@ -51,8 +51,15 @@ namespace nap
 		TextureCube(core)
 	{ }
 
+
 	// Initializes Cube texture. 
 	bool RenderTextureCube::init(utility::ErrorState& errorState)
+	{
+		return init(false, errorState);
+	}
+
+
+	bool RenderTextureCube::init(bool enableMips, utility::ErrorState& errorState)
 	{
 		SurfaceDescriptor settings;
 		settings.mWidth = mWidth;
@@ -115,7 +122,7 @@ namespace nap
 		VkImageUsageFlags required_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
 		// Create render texture
-		return TextureCube::init(settings, mGenerateLODs, mClearColor.toVec4(), required_flags, errorState);
+		return TextureCube::init(settings, enableMips, mClearColor.toVec4(), required_flags, errorState);
 	}
 
 

--- a/system_modules/naprender/src/rendertexturecube.cpp
+++ b/system_modules/naprender/src/rendertexturecube.cpp
@@ -132,12 +132,6 @@ namespace nap
 	}
 
 
-    void RenderTextureCube::syncLayout()
-    {
-        //getHandle().mCurrentLayout = getTargetLayout();
-    }
-
-
 	//////////////////////////////////////////////////////////////////////////
 	// DepthRenderTextureCube
 	//////////////////////////////////////////////////////////////////////////
@@ -166,12 +160,12 @@ namespace nap
 			case DepthRenderTextureCube::EDepthFormat::D16:
 			{
 				settings.mDataType = ESurfaceDataType::USHORT;
-				return TextureCube::init(settings, false, clear_color, required_flags, errorState);
+				return TextureCube::init(settings, 1, clear_color, required_flags, errorState);
 			}
 			case DepthRenderTextureCube::EDepthFormat::D32:
 			{
 				settings.mDataType = ESurfaceDataType::FLOAT;
-				return TextureCube::init(settings, false, clear_color, required_flags, errorState);
+				return TextureCube::init(settings, 1, clear_color, required_flags, errorState);
 			}
 			default:
 			{

--- a/system_modules/naprender/src/rendertexturecube.cpp
+++ b/system_modules/naprender/src/rendertexturecube.cpp
@@ -118,11 +118,17 @@ namespace nap
 			}
 		}
 
+		// Ensure mip-mapping is supported when requested
+		if (!errorState.check(!enableMips || mRenderService.getMipSupport(settings),
+			"%s: hardware mipmap generation not supported", mID.c_str()))
+			return false;
+
 		// Ensure texture can be used as an attachment for a render pass
 		VkImageUsageFlags required_flags = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
 		// Create render texture
-		return TextureCube::init(settings, enableMips, mClearColor.toVec4(), required_flags, errorState);
+		int lvl = enableMips ? utility::computeMipLevel(settings) : 1;
+		return TextureCube::init(settings, lvl, mClearColor.toVec4(), required_flags, errorState);
 	}
 
 

--- a/system_modules/naprender/src/rendertexturecube.cpp
+++ b/system_modules/naprender/src/rendertexturecube.cpp
@@ -121,7 +121,7 @@ namespace nap
 
     void RenderTextureCube::syncLayout()
     {
-        getHandle().mCurrentLayout = getTargetLayout();
+        //getHandle().mCurrentLayout = getTargetLayout();
     }
 
 

--- a/system_modules/naprender/src/rendertexturecube.h
+++ b/system_modules/naprender/src/rendertexturecube.h
@@ -54,11 +54,19 @@ namespace nap
 		RenderTextureCube(Core& core);
 
 		/**
-		 * Creates the texture on the GPU.
+		 * Creates the texture on the GPU without mip-maps.
 		 * @param errorState Contains error state if the function fails.
 		 * @return if the texture was created successfully
 		 */
 		virtual bool init(utility::ErrorState& errorState) override;
+
+		/**
+		 * Creates the texture on the GPU with or without mip-maps.
+		 * @param enableMips if mip-maps should be generated
+		 * @param errorState Contains error state if the function fails.
+		 * @return if the texture was created successfully
+		 */
+		virtual bool init(bool enableMips, utility::ErrorState& errorState);
 
         /**
          * Updates image layout to the target layout after a render pass.
@@ -70,9 +78,6 @@ namespace nap
 		EColorSpace			mColorSpace = EColorSpace::Linear;				///< Property: 'ColorSpace' texture color space
 		EFormat				mColorFormat = EFormat::RGBA8;					///< Property: 'ColorFormat' color texture format
 		RGBAColorFloat		mClearColor = { 0.0f, 0.0f, 0.0f, 0.0f };		///< Property: 'ClearColor' color selection used for clearing the texture
-
-	protected:
-		bool				mGenerateLODs = false;
 	};
 
 

--- a/system_modules/naprender/src/rendertexturecube.h
+++ b/system_modules/naprender/src/rendertexturecube.h
@@ -68,11 +68,6 @@ namespace nap
 		 */
 		virtual bool init(bool enableMips, utility::ErrorState& errorState);
 
-        /**
-         * Updates image layout to the target layout after a render pass.
-         */
-        void syncLayout();
-
 		int					mWidth = 0;										///< Property: 'Width' width of a cube face texture in texels
 		int					mHeight = 0;									///< Property: 'Height' of a cube face texture in texels
 		EColorSpace			mColorSpace = EColorSpace::Linear;				///< Property: 'ColorSpace' texture color space

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -263,6 +263,11 @@ namespace nap
 		 */
 		virtual VkRenderPass getRenderPass() const override							{ return mRenderPass; }
 
+		/**
+		 * @return layout of the texture when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override						{ return VK_IMAGE_LAYOUT_PRESENT_SRC_KHR; }
+
 		bool					mSampleShading		= true;								///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost.
 		int						mWidth				= 512;								///< Property: 'Width' window horizontal resolution
 		int						mHeight				= 512;								///< Property: 'Height' window vertical resolution

--- a/system_modules/naprender/src/snapshot.cpp
+++ b/system_modules/naprender/src/snapshot.cpp
@@ -119,7 +119,7 @@ namespace nap
 			cell = std::make_unique<RenderTexture2D>(mRenderService->getCore());
 			cell->mWidth = mCellWidth;
 			cell->mHeight = mCellHeight;
-			cell->mUsage = Texture::EUsage::DynamicRead;
+			cell->mUsage = Texture2D::EUsage::DynamicRead;
 			cell->mColorFormat = mTextureFormat;
 
 			if (!cell->init(errorState)) 

--- a/system_modules/naprender/src/snapshotrendertarget.cpp
+++ b/system_modules/naprender/src/snapshotrendertarget.cpp
@@ -149,7 +149,8 @@ namespace nap
 	//////////////////////////////////////////////////////////////////////////
 
 	SnapshotRenderTarget::SnapshotRenderTarget(Core& core) :
-		mRenderService(core.getService<RenderService>())
+		mRenderService(core.getService<RenderService>()),
+		mTextureLink(*this)
 	{}
 
 	SnapshotRenderTarget::~SnapshotRenderTarget()
@@ -293,13 +294,13 @@ namespace nap
 		vkCmdSetViewport(mRenderService->getCurrentCommandBuffer(), 0, 1, &viewport);
 	}
 
+
 	void SnapshotRenderTarget::endRendering()
 	{
+		// Finalize rendering and sync layout
 		vkCmdEndRenderPass(mRenderService->getCurrentCommandBuffer());
-
-        // Sync image data with render pass final layout
-        for (auto& tex : mSnapshot->mColorTextures)
-            tex->syncLayout();
+		for (auto& tex : mSnapshot->mColorTextures)
+			mTextureLink.sync(*tex);
 	}
 
 

--- a/system_modules/naprender/src/snapshotrendertarget.h
+++ b/system_modules/naprender/src/snapshotrendertarget.h
@@ -103,6 +103,11 @@ namespace nap
 		 * @return if sample based shading is enabled when rendering to the target.
 		 */
 		virtual bool getSampleShadingEnabled() const override;
+
+		/**
+		 * @return layout of the texture when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override					{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; }
 		
 		/**
 		 * @param cellIndex change the index of the cell to setup for rendering

--- a/system_modules/naprender/src/snapshotrendertarget.h
+++ b/system_modules/naprender/src/snapshotrendertarget.h
@@ -9,6 +9,7 @@
 #include "renderutils.h"
 #include "imagedata.h"
 #include "snapshot.h"
+#include "texturelink.h"
 
 // External Includes
 #include <vulkan/vulkan_core.h>
@@ -130,6 +131,7 @@ namespace nap
 		VkRenderPass				mRenderPass = VK_NULL_HANDLE;
 		ImageData					mDepthImage;
 		ImageData					mColorImage;
+		Texture2DTargetLink			mTextureLink;
 
 		uint32_t					mCellIndex = 0;
 	};

--- a/system_modules/naprender/src/texture.cpp
+++ b/system_modules/naprender/src/texture.cpp
@@ -268,6 +268,7 @@ namespace nap
 		}
 
 		// Create GPU image
+		// TODO: The usage flags could be more fine grained based on selected usage type
 		VkImageUsageFlags use_flags = requiredFlags | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 		if (!create2DImage(vulkan_allocator, descriptor.mWidth, descriptor.mHeight, mFormat, mMipLevels,
 			VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_TILING_OPTIMAL, use_flags, VMA_MEMORY_USAGE_GPU_ONLY, mImageData.mImage, mImageData.mAllocation, mImageData.mAllocationInfo, errorState))
@@ -536,12 +537,13 @@ namespace nap
 		}
 
 		// Set image usage flags: can be written to, read and sampled
-		VkImageUsageFlags usage = requiredFlags | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+		// TODO: The usage flags could be more fine grained
+		VkImageUsageFlags use_flags = requiredFlags | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
 		// Create GPU image
 		VmaAllocator vulkan_allocator = mRenderService.getVulkanAllocator();
 		if (!createLayered2DImage(vulkan_allocator, descriptor.mWidth, descriptor.mHeight, mFormat, mMipLevels, getLayerCount(),
-			VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_TILING_OPTIMAL, usage, VMA_MEMORY_USAGE_GPU_ONLY, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, mImageData.mImage, mImageData.mAllocation, mImageData.mAllocationInfo, errorState))
+			VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_TILING_OPTIMAL, use_flags, VMA_MEMORY_USAGE_GPU_ONLY, VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT, mImageData.mImage, mImageData.mAllocation, mImageData.mAllocationInfo, errorState))
 			return false;
 
 		// Check whether the texture is flagged as depth

--- a/system_modules/naprender/src/texture.cpp
+++ b/system_modules/naprender/src/texture.cpp
@@ -197,7 +197,7 @@ namespace nap
 
 		// Store number of mip-maps to generate
 		mMipLevels = mipCount;
-		if (!errorState.check(mMipLevels > 0, "%s, Mip map count must be equal or higher than 1", mID.c_str()))
+		if (!errorState.check(mMipLevels > 0, "%s, Mip map count must be equal to or higher than 1", mID.c_str()))
 			return false;
 
 		// Create staging buffers for up and download
@@ -512,7 +512,7 @@ namespace nap
 	{
 		// Store number of mip-maps to generate
 		mMipLevels = mipCount;
-		if (!errorState.check(mMipLevels > 0, "%s, Mip map count must be equal or higher than 1", mID.c_str()))
+		if (!errorState.check(mMipLevels > 0, "%s, Mip map count must be equal to or higher than 1", mID.c_str()))
 			return false;
 
 		// Get the format, when unsupported bail.

--- a/system_modules/naprender/src/texture.cpp
+++ b/system_modules/naprender/src/texture.cpp
@@ -14,11 +14,11 @@
 #include <nap/logger.h>
 #include <glm/gtc/type_ptr.hpp>
 
-RTTI_BEGIN_ENUM(nap::Texture::EUsage)
-	RTTI_ENUM_VALUE(nap::Texture::EUsage::Static,		"Static"),
-	RTTI_ENUM_VALUE(nap::Texture::EUsage::DynamicRead,	"DynamicRead"),
-	RTTI_ENUM_VALUE(nap::Texture::EUsage::DynamicWrite,	"DynamicWrite"),
-	RTTI_ENUM_VALUE(nap::Texture::EUsage::Internal,		"Internal")
+RTTI_BEGIN_ENUM(nap::Texture2D::EUsage)
+	RTTI_ENUM_VALUE(nap::Texture2D::EUsage::Static,			"Static"),
+	RTTI_ENUM_VALUE(nap::Texture2D::EUsage::DynamicRead,	"DynamicRead"),
+	RTTI_ENUM_VALUE(nap::Texture2D::EUsage::DynamicWrite,	"DynamicWrite"),
+	RTTI_ENUM_VALUE(nap::Texture2D::EUsage::Internal,		"Internal")
 RTTI_END_ENUM
 
 // Define Texture base
@@ -81,17 +81,17 @@ namespace nap
 	}
 
 
-	static int getNumStagingBuffers(int maxFramesInFlight, Texture::EUsage textureUsage)
+	static int getNumStagingBuffers(int maxFramesInFlight, Texture2D::EUsage textureUsage)
 	{
 		switch (textureUsage)
 		{
-		case Texture::EUsage::DynamicWrite:
-				return maxFramesInFlight + 1;
-			case Texture::EUsage::Static:
+			case Texture2D::EUsage::Static:
 				return 1;
-			case Texture::EUsage::DynamicRead:
+			case Texture2D::EUsage::DynamicRead:
 				return maxFramesInFlight;
-			case Texture::EUsage::Internal:
+			case Texture2D::EUsage::DynamicWrite:
+				return maxFramesInFlight + 1;
+			case Texture2D::EUsage::Internal:
 				return 0;
 			default:
 				assert(false);

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -269,7 +269,14 @@ namespace nap
 		std::vector<TextureReadCallback>	mReadCallbacks;								///< Number of callbacks based on number of frames in flight
 		std::vector<int>					mDownloadStagingBufferIndices;				///< Staging buffer indices associated with a frameindex
 		uint32								mMipLevels = 1;								///< Total number of generated mip-maps
-		EUsage								mUsage;
+		EUsage								mUsage;										///< Intented texture usage
+
+	private:
+		/**
+		 * Creates the various staging buffers, required for data up and download.
+		 * @param usage the intended texture usage
+		 */
+		bool initStagingBuffers(EUsage usage, size_t imageSizeBytes, utility::ErrorState& error);
 	};
 
 
@@ -343,8 +350,6 @@ namespace nap
 		 * @return Vulkan GPU data handle, including image and view.
 		 */
 		virtual ImageData& getHandle() override					{ return mImageData; }
-
-		const EUsage						mUsage = EUsage::Static;					///< Texture usage (cube maps are currently always static)
 
 	protected:
 		ImageData							mImageData = { TextureCube::layerCount };	///< Cube Texture vulkan image buffers

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -74,12 +74,12 @@ namespace nap
 		const SurfaceDescriptor& getDescriptor() const			{ return mDescriptor; }
 
 		/**
-		 * @return render service
+		 * @return render service, available after construction
 		 */
 		RenderService& getRenderService()						{ return mRenderService; }
 
 		/**
-		 * @return render service
+		 * @return render service, available after construction
 		 */
 		const RenderService& getRenderService() const			{ return mRenderService; }
 

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -300,13 +300,13 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings. The texture is cleared to 'ClearColor'.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param generateMips if mip-maps are auto generated
+		 * @param mipCount number of mip-maps to generate when cubemap is created
 		 * @param clearColor the color to clear the texture with.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, bool generateMips, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, int mipCount, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * @return size of the texture in texels.

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -31,17 +31,6 @@ namespace nap
 		friend class RenderService;
 		RTTI_ENABLE(Resource)
 	public:
-		/**
-		 * Flag that determines how the texture is used at runtime.
-		 */
-		enum class EUsage
-		{
-			Static			= 0,	///< Texture is uploaded to once and does not change
-			DynamicRead		= 1,	///< Texture is frequently read from GPU to CPU
-			DynamicWrite	= 2,	///< Texture is frequently updated from CPU to GPU
-			Internal		= 3		///< Texture is never uploaded to or downloaded from
-		};
-
 		// Constructor
 		Texture(Core& core);
 
@@ -128,9 +117,20 @@ namespace nap
 		friend class RenderService;
         friend void utility::blit(VkCommandBuffer, Texture2D&, Texture2D&);
         friend void utility::copy(VkCommandBuffer, Texture2D&, Texture2D&);
-
 		RTTI_ENABLE(Texture)
+
 	public:
+		/**
+		 * Flag that determines how the 2D texture is used at runtime.
+		 */
+		enum class EUsage
+		{
+			Static			= 0,	///< Texture is uploaded to once and does not change
+			DynamicRead		= 1,	///< Texture is frequently read from GPU to CPU
+			DynamicWrite	= 2,	///< Texture is frequently updated from CPU to GPU
+			Internal		= 3		///< Texture is never uploaded to or downloaded from
+		};
+
 		Texture2D(Core& core);
 		virtual ~Texture2D() override;
 

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -63,11 +63,6 @@ namespace nap
 		virtual const ImageData& getHandle() const = 0;
 
 		/**
-		 * @return Vulkan image layout that this texture is intended for.
-		 */
-		virtual VkImageLayout getTargetLayout() const			{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; };
-
-		/**
 		 * @return Vulkan texture format
 		 */
 		VkFormat getFormat() const								{ return mFormat; }
@@ -113,6 +108,7 @@ namespace nap
 		 */
 		void requestClear();
 
+	protected:
 		RenderService&						mRenderService;								///< Reference to the render service
 		SurfaceDescriptor					mDescriptor;								///< Texture description
 		VkFormat							mFormat = VK_FORMAT_UNDEFINED;				///< Vulkan texture format
@@ -148,18 +144,6 @@ namespace nap
 		 * @return if the texture initialized successfully.
 		 */
 		bool init(const SurfaceDescriptor& descriptor, bool generateMipMaps, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
-
-		/**
-		 * Creates the texture on the GPU using the provided settings. The texture is cleared to 'ClearColor'.
-		 * Otherwise the layout of the texture on the GPU will be undefined until upload.
-		 * The Vulkan image usage flags are derived from texture usage.
-		 * @param descriptor texture description.
-		 * @param generateMipMaps if mip maps are generated when data is uploaded.
-		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
-		 * @param errorState contains the error if the texture can't be initialized.
-		 * @return if the texture initialized successfully.
-		 */
-		bool init(const SurfaceDescriptor& descriptor, bool generateMipMaps, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * Creates the texture on the GPU using the provided settings and immediately requests a content upload.

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -139,26 +139,26 @@ namespace nap
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
 		 * @param usage how the texture is intended to be used (static, internal only etc..)
-		 * @param generateMipMaps if mip maps are generated when data is uploaded.
+		 * @param mipCount total number of mip-maps to generate upon upload, a value of 1 disables mip-mapping
 		 * @param clearColor the color to clear the texture with.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, int mipCount, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * Creates the texture on the GPU using the provided settings and immediately requests a content upload.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
 		 * @param usage how the texture is intended to be used (static, internal only etc..)
-		 * @param generateMipMaps if mip maps are generated when data is uploaded.
+		 * @param mipCount total number of mip-maps to generate upon upload, a value of 1 disables mip-mapping
 		 * @param initialData the data to upload, must be of size SurfaceDescriptor::getSizeInBytes().
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, void* initialData, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, int mipCount, void* initialData, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * @return size of the texture in texels.
@@ -233,12 +233,12 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param enableMips if mip maps are generated when data is uploaded.
+		 * @param mipCount total number of mip-maps to generate upon upload
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool initInternal(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool initInternal(const SurfaceDescriptor& descriptor, EUsage usage, int mipCount, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * Called by the render service when data can be uploaded

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -138,7 +138,7 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings. The texture is cleared to 'ClearColor'.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param usage how the texture is intended to be used
+		 * @param usage how the texture is intended to be used (static, internal only etc..)
 		 * @param generateMipMaps if mip maps are generated when data is uploaded.
 		 * @param clearColor the color to clear the texture with.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
@@ -151,7 +151,7 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings and immediately requests a content upload.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param usage how the texture is intended to be used
+		 * @param usage how the texture is intended to be used (static, internal only etc..)
 		 * @param generateMipMaps if mip maps are generated when data is uploaded.
 		 * @param initialData the data to upload, must be of size SurfaceDescriptor::getSizeInBytes().
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags
@@ -300,13 +300,13 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings. The texture is cleared to 'ClearColor'.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param generateMipMaps if mip-maps are auto generated
+		 * @param generateMips if mip-maps are auto generated
 		 * @param clearColor the color to clear the texture with.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, bool generateMipMaps, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, bool generateMips, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * @return size of the texture in texels.

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -36,9 +36,10 @@ namespace nap
 		 */
 		enum class EUsage
 		{
-			Static,				///< Texture does not change, uploaded to once
-			DynamicRead,		///< Texture is frequently read from GPU to CPU
-			DynamicWrite		///< Texture is frequently updated from CPU to GPU
+			Static			= 0,	///< Texture is uploaded to once and does not change
+			DynamicRead		= 1,	///< Texture is frequently read from GPU to CPU
+			DynamicWrite	= 2,	///< Texture is frequently updated from CPU to GPU
+			Internal		= 3		///< Texture is never uploaded to or downloaded from
 		};
 
 		// Constructor
@@ -137,25 +138,27 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings. The texture is cleared to 'ClearColor'.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
+		 * @param usage how the texture is intended to be used
 		 * @param generateMipMaps if mip maps are generated when data is uploaded.
 		 * @param clearColor the color to clear the texture with.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags.
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, bool generateMipMaps, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * Creates the texture on the GPU using the provided settings and immediately requests a content upload.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
+		 * @param usage how the texture is intended to be used
 		 * @param generateMipMaps if mip maps are generated when data is uploaded.
 		 * @param initialData the data to upload, must be of size SurfaceDescriptor::getSizeInBytes().
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool init(const SurfaceDescriptor& descriptor, bool generateMipMaps, void* initialData, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, void* initialData, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * @return size of the texture in texels.
@@ -220,8 +223,6 @@ namespace nap
 		 */
 		void asyncGetData(std::function<void(const void*, size_t)> copyFunction);
 
-		EUsage mUsage = EUsage::Static;							///< Property: 'Usage' If this texture is updated frequently or considered static.
-
 	protected:
 		/**
 		 * @return Vulkan GPU data handle, including image and view.
@@ -232,12 +233,12 @@ namespace nap
 		 * Creates the texture on the GPU using the provided settings.
 		 * The Vulkan image usage flags are derived from texture usage.
 		 * @param descriptor texture description.
-		 * @param generateMipMaps if mip maps are generated when data is uploaded.
+		 * @param enableMips if mip maps are generated when data is uploaded.
 		 * @param requiredFlags image usage flags that are required, 0 = no additional usage flags
 		 * @param errorState contains the error if the texture can't be initialized.
 		 * @return if the texture initialized successfully.
 		 */
-		bool initInternal(const SurfaceDescriptor& descriptor, bool generateMipMaps, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
+		bool initInternal(const SurfaceDescriptor& descriptor, EUsage usage, bool enableMips, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState);
 
 		/**
 		 * Called by the render service when data can be uploaded
@@ -268,6 +269,7 @@ namespace nap
 		std::vector<TextureReadCallback>	mReadCallbacks;								///< Number of callbacks based on number of frames in flight
 		std::vector<int>					mDownloadStagingBufferIndices;				///< Staging buffer indices associated with a frameindex
 		uint32								mMipLevels = 1;								///< Total number of generated mip-maps
+		EUsage								mUsage;
 	};
 
 

--- a/system_modules/naprender/src/texture.h
+++ b/system_modules/naprender/src/texture.h
@@ -22,6 +22,8 @@ namespace nap
 	class Bitmap;
 	class RenderService;
 	class Core;
+	class TextureLink2D;
+	class TextureLinkCube;
 
 	/**
 	 * Texture base class
@@ -115,6 +117,7 @@ namespace nap
 	class NAPAPI Texture2D : public Texture
 	{
 		friend class RenderService;
+		friend class Texture2DLink;
         friend void utility::blit(VkCommandBuffer, Texture2D&, Texture2D&);
         friend void utility::copy(VkCommandBuffer, Texture2D&, Texture2D&);
 		RTTI_ENABLE(Texture)
@@ -223,6 +226,10 @@ namespace nap
 		 */
 		void asyncGetData(std::function<void(const void*, size_t)> copyFunction);
 
+		// Don't allow implicit conversion from bool to int -> EVIL
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool mipCount, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState) = delete;
+		bool init(const SurfaceDescriptor& descriptor, EUsage usage, bool mipCount, void* initialData, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState) = delete;
+
 	protected:
 		/**
 		 * @return Vulkan GPU data handle, including image and view.
@@ -295,6 +302,7 @@ namespace nap
 	class NAPAPI TextureCube : public Texture
 	{
 		friend class RenderService;
+		friend class TextureCubeLink;
 		RTTI_ENABLE(Texture)
 	public:
 		// The image layer count is equal to the number of sides of a cube
@@ -350,6 +358,9 @@ namespace nap
 		 * @return Vulkan GPU data handle, including image and view.
 		 */
 		virtual ImageData& getHandle() override					{ return mImageData; }
+
+		// Don't allow implicit conversion from bool to int -> EVIL
+		bool init(const SurfaceDescriptor& descriptor, bool mipCount, const glm::vec4& clearColor, VkImageUsageFlags requiredFlags, utility::ErrorState& errorState) = delete;
 
 	protected:
 		ImageData							mImageData = { TextureCube::layerCount };	///< Cube Texture vulkan image buffers

--- a/system_modules/naprender/src/texturelink.h
+++ b/system_modules/naprender/src/texturelink.h
@@ -1,0 +1,121 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+// Local includes
+#include "texture.h"
+#include "irendertarget.h"
+
+namespace nap
+{
+	/**
+	 * Simple texture 2D layout synchronization interface.
+	 * Allows external code to update texture layout after rendering operations.
+	 * This is a low-level operation and is therefore concealed from the general interface.
+	 */
+	class NAPAPI Texture2DLink
+	{
+	public:
+		// Destructor
+		virtual ~Texture2DLink() = default;
+
+		// Copy is not allowed
+		Texture2DLink(Texture2DLink&) = delete;
+		Texture2DLink& operator=(const Texture2DLink&) = delete;
+
+		// Move is not allowed
+		Texture2DLink(Texture2DLink&&) = delete;
+		Texture2DLink& operator=(Texture2DLink&&) = delete;
+
+	protected:
+		// Only derived classes can create it
+		Texture2DLink() = default;
+
+		/**
+		 * Manual texture 2D layout synchronization.
+		 * Updates texture 2D layout to match the specified target layout
+		 * @param tex texture to sync
+		 * @param new texture image layout
+		 */
+		static void sync(Texture2D& tex, VkImageLayout layout) { tex.mImageData.mCurrentLayout = layout; }
+	};
+
+
+	/**
+	 * Texture 2D layout synchronization interface for 2D render targets.
+	 * Allows render targets to update the texture layout after completion of a render pass.
+	 * This is a low-level operation and is therefore concealed from the general interface.
+	 */
+	class NAPAPI Texture2DTargetLink : public Texture2DLink
+	{
+	public:
+		// Constructor
+		Texture2DTargetLink(const IRenderTarget& target) : mTarget(target) {};
+
+		/**
+		 * Synchronizes texture layout with final layout of the render target
+		 * @param tex the texture to synchronize
+		 */
+		void sync(Texture2D& tex) { Texture2DLink::sync(tex, mTarget.getFinalLayout()); }
+
+	private:
+		const IRenderTarget& mTarget;
+	};
+
+
+	/**
+	 * Simple texture cube layout synchronization interface.
+	 * Allows external objects to modify texture layout after rendering operations.
+	 * This is a low-level operation and is therefore concealed from the general interface.
+	 */
+	class NAPAPI TextureCubeLink
+	{
+	public:
+		// Destructor
+		virtual ~TextureCubeLink() = default;
+
+		// Copy is not allowed
+		TextureCubeLink(TextureCubeLink&) = delete;
+		TextureCubeLink& operator=(const TextureCubeLink&) = delete;
+
+		// Move is not allowed
+		TextureCubeLink(TextureCubeLink&&) = delete;
+		TextureCubeLink& operator=(TextureCubeLink&&) = delete;
+
+	protected:
+		// Only derived classes can create it
+		TextureCubeLink() = default;
+
+		/**
+		 * Manual texture cube layout synchronization.
+		 * Updates texture cube layout to match the specified target layout.
+		 * @param tex texture to sync
+		 * @param new texture image layout
+		 */
+		static void sync(TextureCube& tex, VkImageLayout layout) { tex.mImageData.mCurrentLayout = layout; }
+	};
+
+
+	/**
+	 * Texture cube layout synchronization interface for cube render targets.
+	 * Allows a cube render target to update the texture layout after completion of a render pass.
+	 * This is a low-level operation and is therefore concealed from the general interface.
+	 */
+	class NAPAPI TextureCubeTargetLink : public TextureCubeLink
+	{
+	public:
+		TextureCubeTargetLink(const IRenderTarget& target) : mTarget(target) {};
+
+		/**
+		 * Synchronizes texture layout with final layout of the render target
+		 * @param tex the texture to synchronize
+		 */
+		void sync(TextureCube& tex) { TextureCubeLink::sync(tex, mTarget.getFinalLayout()); }
+
+	private:
+		const IRenderTarget& mTarget;
+	};
+}
+

--- a/system_modules/naprender/src/textureutils.cpp
+++ b/system_modules/naprender/src/textureutils.cpp
@@ -131,23 +131,9 @@ namespace nap
 		}
 
 
-		bool computeMipLevel(const SurfaceDescriptor& descriptor, VkPhysicalDevice device, int& outLevel, utility::ErrorState& errorState)
+		int computeMipLevel(const SurfaceDescriptor& descriptor)
 		{
-			// Get format properties
-			VkFormatProperties properties;
-			vkGetPhysicalDeviceFormatProperties(device, utility::getTextureFormat(descriptor), &properties);
-
-			// Ensure filtered blitting is supported
-			if (!errorState.check((properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) > 0,
-				"Image format does not support linear blitting"))
-			{
-				outLevel = 1;
-				return false;
-			}
-
-			// Compute level
-			outLevel = static_cast<int>(std::floor(std::log2(std::max(descriptor.getWidth(), descriptor.getHeight())))) + 1;
-			return true;
+			return static_cast<int>(std::floor(std::log2(std::max(descriptor.getWidth(), descriptor.getHeight())))) + 1;
 		}
 
 

--- a/system_modules/naprender/src/textureutils.h
+++ b/system_modules/naprender/src/textureutils.h
@@ -45,7 +45,7 @@ namespace nap
 		/**
 		 * Compute maximum texture level of detail
 		 */
-		bool NAPAPI computeMipLevel(const SurfaceDescriptor& descriptor, VkPhysicalDevice device, int& outLevel, utility::ErrorState& errorState);
+		int NAPAPI computeMipLevel(const SurfaceDescriptor& descriptor);
 
 		/**
 		 * Creates mip maps for the specified Vulkan image.

--- a/system_modules/naprender/src/textureutils.h
+++ b/system_modules/naprender/src/textureutils.h
@@ -43,6 +43,11 @@ namespace nap
 			VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask, VkPipelineStageFlags srcStage, VkPipelineStageFlags dstStage, uint mipLevel, uint mipLevelCount, uint layer, uint layerCount, VkImageAspectFlags aspect);
 
 		/**
+		 * Compute maximum texture level of detail
+		 */
+		bool NAPAPI computeMipLevel(const SurfaceDescriptor& descriptor, VkPhysicalDevice device, int& outLevel, utility::ErrorState& errorState);
+
+		/**
 		 * Creates mip maps for the specified Vulkan image.
 		 */
 		void NAPAPI createMipmaps(VkCommandBuffer buffer, ImageData& image, VkFormat imageFormat, VkImageLayout targetLayout, VkImageAspectFlags aspect, uint32 texWidth, uint32 texHeight, uint32 mipLevels);

--- a/system_modules/naprenderadvanced/src/cubedepthrendertarget.h
+++ b/system_modules/naprenderadvanced/src/cubedepthrendertarget.h
@@ -167,8 +167,7 @@ namespace nap
 		bool									mSampleShading = true;										///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost.
 		float									mClearValue = 1.0f;											///< Property: 'ClearValue' value selection used for clearing the render target
 		ERasterizationSamples					mRequestedSamples = ERasterizationSamples::One;				///< Property: 'Samples' The number of samples used during Rasterization. For better results turn on 'SampleShading'.
-		DepthRenderTextureCube::EDepthFormat	mDepthFormat = DepthRenderTextureCube::EDepthFormat::D32;	///< Property: 'DepthFormat' the cube texture depth format.
-																											
+		DepthRenderTextureCube::EDepthFormat	mDepthFormat = DepthRenderTextureCube::EDepthFormat::D32;	///< Property: 'DepthFormat' the cube texture depth format.																											
 		ResourcePtr<DepthRenderTextureCube>		mCubeDepthTexture;											///< Property: 'CubeDepthTexture' Cube depth texture to render to.
 
 	private:

--- a/system_modules/naprenderadvanced/src/cubedepthrendertarget.h
+++ b/system_modules/naprenderadvanced/src/cubedepthrendertarget.h
@@ -117,6 +117,11 @@ namespace nap
 		virtual bool getSampleShadingEnabled() const override					{ return mSampleShading; }
 
 		/**
+		 * @return image layout when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override					{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; }
+
+		/**
 		 * @return the absolute size of a single cube face in pixels.
 		 */
 		glm::ivec2 getSize() const												{ return mSize; }

--- a/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
+++ b/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
@@ -30,7 +30,7 @@ namespace nap
 
 	bool CubeMapFromFile::init(utility::ErrorState& errorState)
 	{
-		if (!RenderTextureCube::init(errorState))
+		if (!RenderTextureCube::init(mGenerateLODs, errorState))
 			return false;
 
 		if (!mSourceImage->getBitmap().initFromFile(mImagePath, errorState))

--- a/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
+++ b/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
@@ -37,7 +37,7 @@ namespace nap
 			return false;
 
 		if (!mSourceImage->init(mSourceImage->getBitmap().mSurfaceDescriptor,
-			EUsage::Static, 1, mSourceImage->getBitmap().getData(), 0, errorState))
+			Texture2D::EUsage::Static, 1, mSourceImage->getBitmap().getData(), 0, errorState))
 			return false;
 
 		mRenderAdvancedService->registerCubeMap(*this);

--- a/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
+++ b/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
@@ -37,7 +37,7 @@ namespace nap
 			return false;
 
 		if (!mSourceImage->init(mSourceImage->getBitmap().mSurfaceDescriptor,
-			EUsage::Static, false, mSourceImage->getBitmap().getData(), 0, errorState))
+			EUsage::Static, 1, mSourceImage->getBitmap().getData(), 0, errorState))
 			return false;
 
 		mRenderAdvancedService->registerCubeMap(*this);

--- a/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
+++ b/system_modules/naprenderadvanced/src/cubemapfromfile.cpp
@@ -33,11 +33,11 @@ namespace nap
 		if (!RenderTextureCube::init(errorState))
 			return false;
 
-		mSourceImage->mUsage = EUsage::Static;
 		if (!mSourceImage->getBitmap().initFromFile(mImagePath, errorState))
 			return false;
 
-		if (!mSourceImage->init(mSourceImage->getBitmap().mSurfaceDescriptor, false, mSourceImage->getBitmap().getData(), 0, errorState))
+		if (!mSourceImage->init(mSourceImage->getBitmap().mSurfaceDescriptor,
+			EUsage::Static, false, mSourceImage->getBitmap().getData(), 0, errorState))
 			return false;
 
 		mRenderAdvancedService->registerCubeMap(*this);

--- a/system_modules/naprenderadvanced/src/cubemapfromfile.h
+++ b/system_modules/naprenderadvanced/src/cubemapfromfile.h
@@ -67,10 +67,9 @@ namespace nap
 		Texture2D& getSourceTexture() const				{ return *mSourceImage; }
 
 	public:
-		std::string					mImagePath;								///< Property: 'ImagePath' Path to the image on disk to load
-		bool						mSampleShading = false;					///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost
-
-		using RenderTextureCube::mGenerateLODs;								///< Property: 'GenerateLODs' whether to use and update mip-maps each time the cube texture is updated
+		std::string		mImagePath;					///< Property: 'ImagePath' Path to the image on disk to load
+		bool			mSampleShading = false;		///< Property: 'SampleShading' Reduces texture aliasing when enabled, at higher computational cost
+		bool			mGenerateLODs;				///< Property: 'GenerateLODs' whether to use and update mip-maps each time the cube texture is updated
 
 	private:
 		RenderAdvancedService*				mRenderAdvancedService = nullptr;

--- a/system_modules/naprenderadvanced/src/cuberendertarget.cpp
+++ b/system_modules/naprenderadvanced/src/cuberendertarget.cpp
@@ -131,7 +131,7 @@ namespace nap
 
 		// Create render pass based on number of multi samples
 		// When there's only 1 there's no need for a resolve step
-		if (!createRenderPass(mRenderService->getDevice(), mVulkanColorFormat, mVulkanDepthFormat, VK_SAMPLE_COUNT_1_BIT, mCubeTexture->getTargetLayout(), mRenderPass, errorState))
+		if (!createRenderPass(mRenderService->getDevice(), mVulkanColorFormat, mVulkanDepthFormat, VK_SAMPLE_COUNT_1_BIT, getFinalLayout(), mRenderPass, errorState))
 			return false;
 
 		framebuffer_info.renderPass = mRenderPass;

--- a/system_modules/naprenderadvanced/src/cuberendertarget.cpp
+++ b/system_modules/naprenderadvanced/src/cuberendertarget.cpp
@@ -228,11 +228,11 @@ namespace nap
 
 	void CubeRenderTarget::renderInternal(const glm::vec3& camPosition, const glm::mat4& projectionMatrix, CubeRenderTargetCallback renderCallback)
 	{
-		/*
+		/**
 		 * Render to frame buffers
 		 * Cube face selection following the Vulkan spec
 		 * https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap16.html#_cube_map_face_selection_and_transformations
-		 **/
+		 */
 		const auto cam_translation = glm::translate(glm::identity<glm::mat4>(), camPosition);
 		for (int layer_index = TextureCube::layerCount - 1; layer_index >= 0; layer_index--)
 		{

--- a/system_modules/naprenderadvanced/src/cuberendertarget.cpp
+++ b/system_modules/naprenderadvanced/src/cuberendertarget.cpp
@@ -77,7 +77,8 @@ namespace nap
 	//////////////////////////////////////////////////////////////////////////
 
 	CubeRenderTarget::CubeRenderTarget(Core& core) :
-		mRenderService(core.getService<RenderService>())
+		mRenderService(core.getService<RenderService>()),
+		mTextureLink(*this)
 	{}
 
 
@@ -227,7 +228,7 @@ namespace nap
 
 	void CubeRenderTarget::renderInternal(const glm::vec3& camPosition, const glm::mat4& projectionMatrix, CubeRenderTargetCallback renderCallback)
 	{
-		/**
+		/*
 		 * Render to frame buffers
 		 * Cube face selection following the Vulkan spec
 		 * https://registry.khronos.org/vulkan/specs/1.3-extensions/html/chap16.html#_cube_map_face_selection_and_transformations
@@ -245,7 +246,7 @@ namespace nap
 		}
 
         // Sync image data with render pass final layout
-        mCubeTexture->syncLayout();
+		mTextureLink.sync(*mCubeTexture);
 
 		// Update mip maps
 		if (mUpdateLODs && mCubeTexture->getMipLevels() > 1)

--- a/system_modules/naprenderadvanced/src/cuberendertarget.h
+++ b/system_modules/naprenderadvanced/src/cuberendertarget.h
@@ -125,6 +125,11 @@ namespace nap
 		virtual bool getSampleShadingEnabled() const override					{ return mSampleShading; }
 
 		/**
+		 * @return layout of the texture when render pass ends
+		 */
+		virtual VkImageLayout getFinalLayout() const override					{ return VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL; }
+
+		/**
 		 * @return the absolute size of a single cube face in pixels.
 		 */
 		glm::ivec2 getSize() const												{ return mSize; }

--- a/system_modules/naprenderadvanced/src/cuberendertarget.h
+++ b/system_modules/naprenderadvanced/src/cuberendertarget.h
@@ -12,6 +12,7 @@
 #include <nap/resource.h>
 #include <nap/resourceptr.h>
 #include <vulkan/vulkan_core.h>
+#include <texturelink.h>
 
 namespace nap
 {
@@ -217,5 +218,6 @@ namespace nap
 
 		glm::ivec2								mSize = { 0, 0 };
 		uint									mLayerIndex = 0;
+		TextureCubeTargetLink					mTextureLink;
 	};
 }

--- a/system_modules/naprenderadvanced/src/renderadvancedservice.cpp
+++ b/system_modules/naprenderadvanced/src/renderadvancedservice.cpp
@@ -144,7 +144,7 @@ namespace nap
 		mShadowTextureDummy->mID = utility::stringFormat("%s_Dummy_%s", RTTI_OF(DepthRenderTexture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
 		mShadowTextureDummy->mWidth = 1;
 		mShadowTextureDummy->mHeight = 1;
-		mShadowTextureDummy->mUsage = Texture::EUsage::Static;
+		mShadowTextureDummy->mUsage = Texture::EUsage::Internal;
 		mShadowTextureDummy->mDepthFormat = configuration->mDepthFormat;
 		mShadowTextureDummy->mColorSpace = EColorSpace::Linear;
 		mShadowTextureDummy->mClearValue = 1.0f;
@@ -649,7 +649,7 @@ namespace nap
 				shadow_map->mWidth = light->getShadowMapSize();
 				shadow_map->mHeight = light->getShadowMapSize();
 				shadow_map->mDepthFormat = configuration->mDepthFormat;
-				shadow_map->mUsage = Texture::EUsage::Static;
+				shadow_map->mUsage = Texture::EUsage::Internal;
 				shadow_map->mColorSpace = EColorSpace::Linear;
 				shadow_map->mClearValue = 1.0f;
 				shadow_map->mFill = true;

--- a/system_modules/naprenderadvanced/src/renderadvancedservice.cpp
+++ b/system_modules/naprenderadvanced/src/renderadvancedservice.cpp
@@ -144,7 +144,7 @@ namespace nap
 		mShadowTextureDummy->mID = utility::stringFormat("%s_Dummy_%s", RTTI_OF(DepthRenderTexture2D).get_name().to_string().c_str(), math::generateUUID().c_str());
 		mShadowTextureDummy->mWidth = 1;
 		mShadowTextureDummy->mHeight = 1;
-		mShadowTextureDummy->mUsage = Texture::EUsage::Internal;
+		mShadowTextureDummy->mUsage = Texture2D::EUsage::Internal;
 		mShadowTextureDummy->mDepthFormat = configuration->mDepthFormat;
 		mShadowTextureDummy->mColorSpace = EColorSpace::Linear;
 		mShadowTextureDummy->mClearValue = 1.0f;
@@ -649,7 +649,7 @@ namespace nap
 				shadow_map->mWidth = light->getShadowMapSize();
 				shadow_map->mHeight = light->getShadowMapSize();
 				shadow_map->mDepthFormat = configuration->mDepthFormat;
-				shadow_map->mUsage = Texture::EUsage::Internal;
+				shadow_map->mUsage = Texture2D::EUsage::Internal;
 				shadow_map->mColorSpace = EColorSpace::Linear;
 				shadow_map->mClearValue = 1.0f;
 				shadow_map->mFill = true;

--- a/system_modules/napvideo/src/videoplayer.cpp
+++ b/system_modules/napvideo/src/videoplayer.cpp
@@ -92,7 +92,7 @@ namespace nap
 
 			// Create Y Texture
 			mYTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mYTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mYTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Update dimensions for U and V texture
@@ -103,12 +103,12 @@ namespace nap
 
 			// Create U
 			mUTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mUTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mUTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Create V Texture
 			mVTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mVTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mVTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			mTexturesCreated = true;

--- a/system_modules/napvideo/src/videoplayer.cpp
+++ b/system_modules/napvideo/src/videoplayer.cpp
@@ -12,6 +12,7 @@
 #include <mathutils.h>
 #include <nap/assert.h>
 #include <libavformat/avformat.h>
+#include <glm/gtc/constants.hpp>
 
 // nap::videoplayer run time class definition 
 RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::VideoPlayer, "Decodes a video in a background thread and stores the result in a set of YUV textures.")
@@ -92,7 +93,7 @@ namespace nap
 			// Create Y Texture
 			mYTexture = std::make_unique<Texture2D>(mService.getCore());
 			mYTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mYTexture->init(tex_description, false, 0, error))
+			if (!mYTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Update dimensions for U and V texture
@@ -104,13 +105,13 @@ namespace nap
 			// Create U
 			mUTexture = std::make_unique<Texture2D>(mService.getCore());
 			mUTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mUTexture->init(tex_description, false, 0, error))
+			if (!mUTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Create V Texture
 			mVTexture = std::make_unique<Texture2D>(mService.getCore());
 			mVTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mVTexture->init(tex_description, false, 0, error))
+			if (!mVTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			mTexturesCreated = true;

--- a/system_modules/napvideo/src/videoplayer.cpp
+++ b/system_modules/napvideo/src/videoplayer.cpp
@@ -92,7 +92,7 @@ namespace nap
 
 			// Create Y Texture
 			mYTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mYTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
+			if (!mYTexture->init(tex_description, Texture2D::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Update dimensions for U and V texture
@@ -103,12 +103,12 @@ namespace nap
 
 			// Create U
 			mUTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mUTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
+			if (!mUTexture->init(tex_description, Texture2D::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Create V Texture
 			mVTexture = std::make_unique<Texture2D>(mService.getCore());
-			if (!mVTexture->init(tex_description, Texture::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
+			if (!mVTexture->init(tex_description, Texture2D::EUsage::DynamicWrite, 1, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			mTexturesCreated = true;

--- a/system_modules/napvideo/src/videoplayer.cpp
+++ b/system_modules/napvideo/src/videoplayer.cpp
@@ -92,8 +92,7 @@ namespace nap
 
 			// Create Y Texture
 			mYTexture = std::make_unique<Texture2D>(mService.getCore());
-			mYTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mYTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mYTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Update dimensions for U and V texture
@@ -104,14 +103,12 @@ namespace nap
 
 			// Create U
 			mUTexture = std::make_unique<Texture2D>(mService.getCore());
-			mUTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mUTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mUTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			// Create V Texture
 			mVTexture = std::make_unique<Texture2D>(mService.getCore());
-			mVTexture->mUsage = Texture::EUsage::DynamicWrite;
-			if (!mVTexture->init(tex_description, false, glm::zero<glm::vec4>(), 0, error))
+			if (!mVTexture->init(tex_description, Texture::EUsage::DynamicWrite, false, glm::zero<glm::vec4>(), 0, error))
 				return false;
 
 			mTexturesCreated = true;


### PR DESCRIPTION
This PR introduces texture links: a simple contract that enables external code to update the layout of a texture after completing (for example) a render pass. Because this is a low-level and rather obscure operation is is concealed from the general texture interface, as discussed here: https://github.com/napframework/nap/pull/67#pullrequestreview-2612373185

Only a _link_ can alter `nap::Texture2D` and `nap::TextureCube` image data, which is tied to a render target in the form of a `Texture2DTargetLink` and `TextureCubeTargetLink`. When a render pass ends it simply calls: `Texture2DTargetLink::sync()` to push it's layout to the render texture. You can create new contracts for other types by deriving from `nap::Texture2DLink` and `nap::TextureCubeLink`. 

```
RenderTarget::RenderTarget(Core& core) :
	mRenderService(core.getService<RenderService>()),
	mTextureLink(*this) {}
...
mTextureLink.sync(*mColorTexture);
```

One question: do we prefer _Link_ or _Contract_ for the class name?

I also took the liberty to cleanup the texture interface a bit, without breaking any underlying data. `EUsage` is now local to `nap::Texture2D` instead of `nap::Texture` - cube maps are different and don't offer the same options in terms of IO, they therefore don't require any usage to be specified atm. 

`Texture2D` no longer declares it's intended usage as a property. Instead, it must be explicitly initialized with one when calling `Texture2D::init(usage)`. This places derived classes in control, allowing them to decide which usage is compatible and whether or not it should be exposed - which in my opinion is better because `Texture2D` is intended as an abstract base class.

I made lodding more explicit: Only objects that support LOD (Level of Detail) declare it as a property. They must check compatibility and calculate the maximum LOD level before calling init(), which now accepts a LOD level number instead of a boolean. I introduced  `RenderService::getMipSupport` to check compatibility. Example:

```
// Ensure hardware mip-mapping is supported
if(!errorState.check(!mGenerateLods || mRenderService.getMipSupport(getBitmap().mSurfaceDescriptor),
	"%s: hardware mipmap generation not supported, consider disabling 'GenerateLods'", mID.c_str()))
	return false;

// Initialize
int lvl = mGenerateLods ? utility::computeMipLevel(getBitmap().mSurfaceDescriptor) : 1;
return Texture2D::init(getBitmap().mSurfaceDescriptor, mUsage, lvl, getBitmap().getData(), 0, errorState);
```

I also introduced `Texture2D::EUsage::Internal` - which is now the default for render textures. Previously those were declared static, which tied them to a staging buffer for upload that was often never used. Internal textures are GPU bound and **can't** be uploaded to (CPU to GPU) or downloaded from (GPU to CPU). This is more suitable for render textures and prevents us from allocating an unused buffer on the GPU. I updated all the example projects to use `Internal` textures where appropiate.

`RenderTarget::endRendering` now also syncs the depth texture layout when present. I asssume this to be the right thing to do, but better validate it on your end.