### PR TITLE
Add always on top window flag

### DIFF
--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -1042,7 +1042,7 @@ namespace nap
 
 	void RenderWindow::setAlwaysOnTop(bool onTop)
 	{
-		SDL::setAlwaysOnTop(mSDLWindow, onTop);
+		SDL::setWindowAlwaysOnTop(mSDLWindow, onTop);
 	}
 }
 

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -27,6 +27,7 @@ RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::RenderWindow, "Desktop render windo
 	RTTI_PROPERTY("Borderless",				&nap::RenderWindow::mBorderless,		nap::rtti::EPropertyMetaData::Default,	"If the window has borders")
 	RTTI_PROPERTY("Resizable",				&nap::RenderWindow::mResizable,			nap::rtti::EPropertyMetaData::Default,	"If the window is resizable")
 	RTTI_PROPERTY("Visible",				&nap::RenderWindow::mVisible,			nap::rtti::EPropertyMetaData::Default,	"If the window is visible")
+	RTTI_PROPERTY("AlwaysOnTop",			&nap::RenderWindow::mAlwaysOnTop,		nap::rtti::EPropertyMetaData::Default,	"Bring the window to the front and keep it above the rest")
 	RTTI_PROPERTY("SampleShading",			&nap::RenderWindow::mSampleShading,		nap::rtti::EPropertyMetaData::Default,	"Reduces texture aliasing at higher computational cost")
 	RTTI_PROPERTY("Title",					&nap::RenderWindow::mTitle,				nap::rtti::EPropertyMetaData::Default,	"Window display title")
 	RTTI_PROPERTY("Width",					&nap::RenderWindow::mWidth,				nap::rtti::EPropertyMetaData::Default,	"Horizontal resolution")
@@ -53,13 +54,15 @@ namespace nap
 	{
 		// Construct options
 		Uint32 options = SDL_WINDOW_VULKAN;
-		options = renderWindow.mResizable  ? options | SDL_WINDOW_RESIZABLE : options;
-		options = renderWindow.mBorderless ? options | SDL_WINDOW_BORDERLESS : options;
-		options = allowHighDPI ? options | SDL_WINDOW_ALLOW_HIGHDPI : options;
+		options |= renderWindow.mResizable  ? SDL_WINDOW_RESIZABLE  : 0x0U;
+		options |= renderWindow.mBorderless ? SDL_WINDOW_BORDERLESS : 0x0U;
+		options |= renderWindow.mAlwaysOnTop ? SDL_WINDOW_ALWAYS_ON_TOP : 0x0U;
+		options |= allowHighDPI ? SDL_WINDOW_ALLOW_HIGHDPI : 0x0U;
 
 		// Always hide window until added and configured by render service
-		options = options | SDL_WINDOW_HIDDEN;
+		options |= SDL_WINDOW_HIDDEN;
 
+		// Create window
 		SDL_Window* new_window = SDL_CreateWindow(renderWindow.mTitle.c_str(),
 			SDL_WINDOWPOS_CENTERED,
 			SDL_WINDOWPOS_CENTERED,
@@ -1034,6 +1037,12 @@ namespace nap
 			mSwapchainExtent = mSurfaceCapabilities.currentExtent;
 		}
 		return true;
+	}
+
+
+	void RenderWindow::setAlwaysOnTop(bool onTop)
+	{
+		SDL::setAlwaysOnTop(mSDLWindow, onTop);
 	}
 }
 

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -205,6 +205,12 @@ namespace nap
 		const glm::ivec2 getPosition() const;
 
 		/**
+		 * Moves the window to the front and keeps it there
+		 * @param if the window is moved to the front and kept there.
+		 */
+		void setAlwaysOnTop(bool onTop);
+
+		/**
 		 * @return the hardware window handle, nullptr if undefined
 		 */
 		SDL_Window* getNativeWindow() const;
@@ -284,6 +290,7 @@ namespace nap
 		bool					mBorderless			= false;							///< Property: 'Borderless' if the window has any borders
 		bool					mResizable			= true;								///< Property: 'Resizable' if the window is resizable
 		bool					mVisible			= true;								///< Property: 'Visible' if the render window is visible on screen
+		bool					mAlwaysOnTop		= false;							///< Property: 'AlwaysOnTop' Brings the window to the front and keeps it above the rest
 		EPresentationMode		mMode				= EPresentationMode::Immediate;		///< Property: 'Mode' the image presentation mode to use
 		std::string				mTitle				= "";								///< Property: 'Title' window title
 		RGBAColorFloat			mClearColor			= { 0.0f, 0.0f, 0.0f, 1.0f };		///< Property: 'ClearColor' background clear color

--- a/system_modules/naprender/src/sdlhelpers.cpp
+++ b/system_modules/naprender/src/sdlhelpers.cpp
@@ -45,9 +45,15 @@ namespace nap
 		}
 
 
-		void NAPAPI setAlwaysOnTop(SDL_Window* window, bool enabled)
+		void NAPAPI setWindowAlwaysOnTop(SDL_Window* window, bool enabled)
 		{
 			SDL_SetWindowAlwaysOnTop(window, static_cast<SDL_bool>(enabled));
+		}
+
+
+		void NAPAPI setWindowResizable(SDL_Window* window, bool enabled)
+		{
+			SDL_SetWindowResizable(window, static_cast<SDL_bool>(enabled));
 		}
 
 

--- a/system_modules/naprender/src/sdlhelpers.cpp
+++ b/system_modules/naprender/src/sdlhelpers.cpp
@@ -45,6 +45,12 @@ namespace nap
 		}
 
 
+		void NAPAPI setAlwaysOnTop(SDL_Window* window, bool enabled)
+		{
+			SDL_SetWindowAlwaysOnTop(window, static_cast<SDL_bool>(enabled));
+		}
+
+
 		void showWindow(SDL_Window* window, bool show)
 		{
 			if (show)

--- a/system_modules/naprender/src/sdlhelpers.h
+++ b/system_modules/naprender/src/sdlhelpers.h
@@ -232,5 +232,11 @@ namespace nap
 		 * @param name the new window name
 		 */
 		void NAPAPI setWindowTitle(SDL_Window* window, const std::string& name);
+
+		/**
+		 * Brings the window to the front and keeps it there
+		 * @param window the window to move to the front and keep on top
+		 */
+		void NAPAPI setAlwaysOnTop(SDL_Window* window, bool enabled);
 	}
 }

--- a/system_modules/naprender/src/sdlhelpers.h
+++ b/system_modules/naprender/src/sdlhelpers.h
@@ -236,7 +236,15 @@ namespace nap
 		/**
 		 * Brings the window to the front and keeps it there
 		 * @param window the window to move to the front and keep on top
+		 * @param enabled if always on top should be enabled
 		 */
-		void NAPAPI setAlwaysOnTop(SDL_Window* window, bool enabled);
+		void NAPAPI setWindowAlwaysOnTop(SDL_Window* window, bool enabled);
+
+		/**
+		 * Turn resizing of a window by a user on or off.
+		 * @param window the resize window 
+		 * @param enabled resize flag
+		 */
+		void NAPAPI setWindowResizable(SDL_Window* window, bool enabled);
 	}
 }

--- a/tools/napkin/src/main.cpp
+++ b/tools/napkin/src/main.cpp
@@ -188,6 +188,7 @@ int main(int argc, char* argv[])
 	app.setWindowIcon(QIcon(napkin::QRC_ICONS_NAP_ICON));
 	std::unique_ptr<napkin::MainWindow> w = std::make_unique<napkin::MainWindow>();
 	QFont applied_font = w->font();
+	applied_font.setStyleStrategy(QFont::PreferQuality);
 	applied_font.setHintingPreference(QFont::PreferNoHinting);
 	w->setFont(applied_font);
 	w->show();


### PR DESCRIPTION
Add `nap::RenderWindow::AlwaysOnTop` property to move a window to the front and keep it there. This property can also be set as a flag at runtime through: `nap::RenderWindow::setAlwaysOnTop()`. 