### PR TITLE
MidiInputPort and MidiOutputPort fix

### DIFF
--- a/system_modules/napmidi/src/midiport/midiinputport.cpp
+++ b/system_modules/napmidi/src/midiport/midiinputport.cpp
@@ -9,7 +9,8 @@
 // External Includes
 #include <nap/logger.h>
 
-RTTI_BEGIN_CLASS(nap::MidiInputPort, "Opens one or more midi input ports")
+RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::MidiInputPort, "Opens one or more midi input ports")
+	RTTI_CONSTRUCTOR(nap::Core&)
     RTTI_PROPERTY("Ports", &nap::MidiInputPort::mPortNames, nap::rtti::EPropertyMetaData::Default, "Names of the ports to open and monitor, empty = all ports")
     RTTI_PROPERTY("EnableDebugOutput", &nap::MidiInputPort::mDebugOutput, nap::rtti::EPropertyMetaData::Default, "Log incoming messages for debug purposes")
 RTTI_END_CLASS
@@ -29,8 +30,8 @@ namespace nap
     }
     
     
-    MidiInputPort::MidiInputPort(MidiService& service) :
-		mService(&service)
+    MidiInputPort::MidiInputPort(Core& core) :
+		mService(core.getService<MidiService>())
     { }
 
 

--- a/system_modules/napmidi/src/midiport/midiinputport.h
+++ b/system_modules/napmidi/src/midiport/midiinputport.h
@@ -11,6 +11,7 @@
 #include <rtti/object.h>
 #include <utility/dllexport.h>
 #include <nap/device.h>
+#include <nap/core.h>
 
 namespace nap
 {
@@ -23,8 +24,7 @@ namespace nap
     {
         RTTI_ENABLE(Device)
     public:
-		MidiInputPort() = default;
-        MidiInputPort(MidiService& service);
+		MidiInputPort(Core& core);
 
         /**
          * Starts the midi input port.

--- a/system_modules/napmidi/src/midiport/midioutputport.cpp
+++ b/system_modules/napmidi/src/midiport/midioutputport.cpp
@@ -9,14 +9,15 @@
 // External Includes
 #include <nap/logger.h>
 
-RTTI_BEGIN_CLASS(nap::MidiOutputPort, "Opens a midi output port")
+RTTI_BEGIN_CLASS_NO_DEFAULT_CONSTRUCTOR(nap::MidiOutputPort, "Opens a midi output port")
+	RTTI_CONSTRUCTOR(nap::Core&)
 	RTTI_PROPERTY("AllowFailure",	&nap::MidiOutputPort::mAllowFailure,	nap::rtti::EPropertyMetaData::Default, "If opening the port is allowed to fail on initialization")
     RTTI_PROPERTY("Port",			&nap::MidiOutputPort::mPortName,		nap::rtti::EPropertyMetaData::Required, "Name of the port to open")
 RTTI_END_CLASS
 
 namespace nap
 {   
-    MidiOutputPort::MidiOutputPort(MidiService& service) : mService(&service)
+    MidiOutputPort::MidiOutputPort(Core& core) : mService(core.getService<MidiService>())
     {
 		mMidiOut = std::make_unique<RtMidiOut>();
     }

--- a/system_modules/napmidi/src/midiport/midioutputport.h
+++ b/system_modules/napmidi/src/midiport/midioutputport.h
@@ -11,6 +11,7 @@
 // Nap includes
 #include <nap/device.h>
 #include <utility/dllexport.h>
+#include <nap/core.h>
 
 namespace nap
 {
@@ -24,8 +25,7 @@ namespace nap
     {
         RTTI_ENABLE(Device)
     public:
-        MidiOutputPort() = default;
-        MidiOutputPort(MidiService& service);
+        MidiOutputPort(Core& core);
 		virtual ~MidiOutputPort() override;
 
         /**


### PR DESCRIPTION
Fixes (backwards compatibility?) problem with ctors in MidiInputPort and MidiOutputPort that causes the pointer to the MidiService not to be set.