### PR TITLE
Render Window synchronization fix & optimization

### DIFF
--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -476,10 +476,10 @@ namespace nap
 		destroySwapChainResources();
 
 		// Destroy all other  vulkan resources if present
-		for (VkSemaphore semaphore : mImageAvailableSemaphores)
+		for (VkSemaphore semaphore : mAcquireSemaphores)
 			vkDestroySemaphore(mDevice, semaphore, nullptr);
 
-		for (VkSemaphore semaphore : mRenderFinishedSemaphores)
+		for (VkSemaphore semaphore : mSubmitSemaphores)
 			vkDestroySemaphore(mDevice, semaphore, nullptr);
 
 		// Destroy window surface
@@ -558,11 +558,11 @@ namespace nap
 			return false;
 
 		// Create image render sync primitives.
-		if (!createSyncPrimitives(mDevice, mImageAvailableSemaphores, mRenderService->getMaxFramesInFlight(), errorState))
+		if (!createSyncPrimitives(mDevice, mAcquireSemaphores, mRenderService->getMaxFramesInFlight(), errorState))
 			return false;
 
 		// Create presentation sync primitives
-		if (!createSyncPrimitives(mDevice, mRenderFinishedSemaphores, mSwapChainImageCount, errorState))
+		if (!createSyncPrimitives(mDevice, mSubmitSemaphores, mSwapChainImageCount, errorState))
 			return false;
 
 		// Add window to render service
@@ -727,7 +727,7 @@ namespace nap
 		// On which the renderer waits to become available when the queue is submitted in RenderWindow::endRecording().
 		int	current_frame = mRenderService->getCurrentFrameIndex(); 
 		assert(mSwapchain != VK_NULL_HANDLE);
-		VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, mImageAvailableSemaphores[current_frame], VK_NULL_HANDLE, &mPresentIndex);
+		VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, mAcquireSemaphores[current_frame], VK_NULL_HANDLE, &mImageIndex);
 
 		// If the next image is for some reason out of date, recreate the framebuffer the next frame and record nothing.
 		// This situation occurs when the swapchain dimensions don't match the current extent, ie: window has been resized.
@@ -758,8 +758,8 @@ namespace nap
 	void RenderWindow::endRecording()
 	{
 		// Stop recording command buffer
-		int	current_frame = mRenderService->getCurrentFrameIndex();
-		VkCommandBuffer command_buffer = mCommandBuffers[current_frame];
+		int	frame_index = mRenderService->getCurrentFrameIndex();
+		VkCommandBuffer command_buffer = mCommandBuffers[frame_index];
 		if (vkEndCommandBuffer(command_buffer) != VK_SUCCESS) 
 			throw std::runtime_error("failed to record command buffer!");
 
@@ -767,36 +767,34 @@ namespace nap
 		// the GPU will wait for the image available semaphore to be signaled when we start writing to the color attachment.
 		VkSubmitInfo submit_info = {};
 		submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-		VkSemaphore image_available_semaphore[] = { mImageAvailableSemaphores[current_frame] };
 		VkPipelineStageFlags wait_stages[] = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
 		submit_info.waitSemaphoreCount = 1;
-		submit_info.pWaitSemaphores = image_available_semaphore;
+		submit_info.pWaitSemaphores = &mAcquireSemaphores[frame_index];
 		submit_info.pWaitDstStageMask = wait_stages;
 		submit_info.commandBufferCount = 1;
-		submit_info.pCommandBuffers = &mCommandBuffers[current_frame];
+		submit_info.pCommandBuffers = &mCommandBuffers[frame_index];
 
 		// When the command buffer has completed execution, the render finished semaphore is signaled. This semaphore
 		// is used by the GPU presentation engine to wait before presenting the finished image to screen.
-		VkSemaphore render_finished_semaphore[] = { mRenderFinishedSemaphores[mPresentIndex] };
+		VkSemaphore submit_semaphore = mSubmitSemaphores[mImageIndex];
 		submit_info.signalSemaphoreCount = 1;
-		submit_info.pSignalSemaphores = render_finished_semaphore;
+		submit_info.pSignalSemaphores = &submit_semaphore;
 
 		// Submit the queue for rendering
 		VkResult result = vkQueueSubmit(mRenderService->getQueue(), 1, &submit_info, VK_NULL_HANDLE);
 		assert(result == VK_SUCCESS);
 
 		// Set the rendering bit of queue submit ops of the current frame
-		mRenderService->mFramesInFlight[current_frame].mQueueSubmitOps |= RenderService::EQueueSubmitOp::Rendering;
+		mRenderService->mFramesInFlight[frame_index].mQueueSubmitOps |= RenderService::EQueueSubmitOp::Rendering;
 
 		// Create presentation information -> wait for the render finished semaphore to be signalled before presenting
-		VkSwapchainKHR swap_chains[] = { mSwapchain };
 		VkPresentInfoKHR present_info = {};
 		present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
 		present_info.waitSemaphoreCount = 1;
-		present_info.pWaitSemaphores = render_finished_semaphore;
+		present_info.pWaitSemaphores = &submit_semaphore;
 		present_info.swapchainCount = 1;						// Await only the render finished semaphore
-		present_info.pSwapchains = swap_chains;
-		present_info.pImageIndices = &mPresentIndex;
+		present_info.pSwapchains = &mSwapchain;
+		present_info.pImageIndices = &mImageIndex;
 
 		// According to the spec, vkQueuePresentKHR can return VK_ERROR_OUT_OF_DATE_KHR when the framebuffer no longer matches the swapchain.
 		// In our case this should only happen due to window size changes, which is handled in makeCurrent. So, we don't attempt to handle it here.
@@ -947,7 +945,7 @@ namespace nap
 		VkRenderPassBeginInfo render_pass_info = {};
 		render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
 		render_pass_info.renderPass = mRenderPass;
-		render_pass_info.framebuffer = mSwapChainFramebuffers[mPresentIndex];
+		render_pass_info.framebuffer = mSwapChainFramebuffers[mImageIndex];
 		render_pass_info.renderArea.offset = { 0, 0 };
 		render_pass_info.renderArea.extent = mSwapchainExtent;
 

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -767,19 +767,19 @@ namespace nap
 		// the GPU will wait for the image available semaphore to be signaled when we start writing to the color attachment.
 		VkSubmitInfo submit_info = {};
 		submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-		VkSemaphore swap_image_semaphore[] = { mImageAvailableSemaphores[current_frame] };
+		VkSemaphore image_available_semaphore[] = { mImageAvailableSemaphores[current_frame] };
 		VkPipelineStageFlags wait_stages[] = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
 		submit_info.waitSemaphoreCount = 1;
-		submit_info.pWaitSemaphores = swap_image_semaphore;
+		submit_info.pWaitSemaphores = image_available_semaphore;
 		submit_info.pWaitDstStageMask = wait_stages;
 		submit_info.commandBufferCount = 1;
 		submit_info.pCommandBuffers = &mCommandBuffers[current_frame];
 
 		// When the command buffer has completed execution, the render finished semaphore is signaled. This semaphore
 		// is used by the GPU presentation engine to wait before presenting the finished image to screen.
-		VkSemaphore render_semaphore[] = { mRenderFinishedSemaphores[mPresentIndex] };
+		VkSemaphore render_finished_semaphore[] = { mRenderFinishedSemaphores[mPresentIndex] };
 		submit_info.signalSemaphoreCount = 1;
-		submit_info.pSignalSemaphores = render_semaphore;
+		submit_info.pSignalSemaphores = render_finished_semaphore;
 
 		// Submit the queue for rendering
 		VkResult result = vkQueueSubmit(mRenderService->getQueue(), 1, &submit_info, VK_NULL_HANDLE);
@@ -793,7 +793,7 @@ namespace nap
 		VkPresentInfoKHR present_info = {};
 		present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
 		present_info.waitSemaphoreCount = 1;
-		present_info.pWaitSemaphores = render_semaphore;
+		present_info.pWaitSemaphores = render_finished_semaphore;
 		present_info.swapchainCount = 1;						// Await only the render finished semaphore
 		present_info.pSwapchains = swap_chains;
 		present_info.pImageIndices = &mPresentIndex;

--- a/system_modules/naprender/src/renderwindow.cpp
+++ b/system_modules/naprender/src/renderwindow.cpp
@@ -396,21 +396,16 @@ namespace nap
 	}
 
 
-	static bool createSyncObjects(VkDevice device, std::vector<VkSemaphore>& imageAvailableSemaphores, std::vector<VkSemaphore>& renderFinishedSemaphores, int numFramesInFlight, utility::ErrorState& errorState)
+	static bool createSyncPrimitives(VkDevice device, std::vector<VkSemaphore>& semaphores, int count, utility::ErrorState& errorState)
 	{
-		imageAvailableSemaphores.resize(numFramesInFlight);
-		renderFinishedSemaphores.resize(numFramesInFlight);
+		semaphores.resize(count);
+		VkSemaphoreCreateInfo info = {};
+		info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
 
-		VkSemaphoreCreateInfo semaphoreInfo = {};
-		semaphoreInfo.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-
-		for (size_t i = 0; i < numFramesInFlight; i++)
+		for (auto& handle : semaphores)
 		{
-			if (!errorState.check(vkCreateSemaphore(device, &semaphoreInfo, nullptr, &imageAvailableSemaphores[i]) == VK_SUCCESS &&
-				vkCreateSemaphore(device, &semaphoreInfo, nullptr, &renderFinishedSemaphores[i]) == VK_SUCCESS, "Failed to create sync objects"))
-			{
+			if (!errorState.check(vkCreateSemaphore(device, &info, nullptr, &handle) == VK_SUCCESS, "Failed to create image sync primitives"))
 				return false;
-			}
 		}
 		return true;
 	}
@@ -561,10 +556,13 @@ namespace nap
 		// Create swapchain based on current window properties
 		if (!createSwapChainResources(errorState))
 			return false;
-		nap::Logger::info("%s: Created %d swap chain images", mID.c_str(), mSwapChainImageCount);
 
-		// Create frame / GPU synchronization objects
-		if (!createSyncObjects(mDevice, mImageAvailableSemaphores, mRenderFinishedSemaphores, mRenderService->getMaxFramesInFlight(), errorState))
+		// Create image render sync primitives.
+		if (!createSyncPrimitives(mDevice, mImageAvailableSemaphores, mRenderService->getMaxFramesInFlight(), errorState))
+			return false;
+
+		// Create presentation sync primitives
+		if (!createSyncPrimitives(mDevice, mRenderFinishedSemaphores, mSwapChainImageCount, errorState))
 			return false;
 
 		// Add window to render service
@@ -725,11 +723,14 @@ namespace nap
 		if ((SDL::getWindowFlags(mSDLWindow) & SDL_WINDOW_MINIMIZED) != 0)
 			return VK_NULL_HANDLE;
 
+		// Figure out which swapchain image to draw to next, the semaphore is triggered when the image becomes available.
+		// On which the renderer waits to become available when the queue is submitted in RenderWindow::endRecording().
+		int	current_frame = mRenderService->getCurrentFrameIndex(); 
+		assert(mSwapchain != VK_NULL_HANDLE);
+		VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, mImageAvailableSemaphores[current_frame], VK_NULL_HANDLE, &mSwapIndex);
+
 		// If the next image is for some reason out of date, recreate the framebuffer the next frame and record nothing.
 		// This situation occurs when the swapchain dimensions don't match the current extent, ie: window has been resized.
-		int	current_frame = mRenderService->getCurrentFrameIndex();
-		assert(mSwapchain != VK_NULL_HANDLE);
-		VkResult result = vkAcquireNextImageKHR(mDevice, mSwapchain, UINT64_MAX, mImageAvailableSemaphores[current_frame], VK_NULL_HANDLE, &mCurrentImageIndex);
 		if (result == VK_ERROR_OUT_OF_DATE_KHR)
 		{
 			mRecreateSwapchain = true;
@@ -765,50 +766,48 @@ namespace nap
 		// The present engine may give us images out of order. If we receive an image index that was already in flight, we need to wait for it to complete.
 		// We only need to do this right before VkQueueSubmit, to avoid having multiple submits that are waiting on the same image to be returned from the
 		// presentation engine. By waiting until right before the submit, we maximize parallelism with the GPU.
-		if (mImagesInFlight[mCurrentImageIndex] != -1)
-			mRenderService->waitForFence(mImagesInFlight[mCurrentImageIndex]);
+		if (mFramesInFlight[mSwapIndex] != -1)
+			mRenderService->waitForFence(mFramesInFlight[mSwapIndex]);
 
 		// Keep track of the fact that the current image index is in use by the current frame. This ensures we can wait for the frame to
 		// finish if we encounter this image index again in the future.
-		mImagesInFlight[mCurrentImageIndex] = current_frame;
+		mFramesInFlight[mSwapIndex] = current_frame;
 
 		VkSubmitInfo submit_info = {};
 		submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 
 		// GPU needs to wait for the presentation engine to return the image to the swapchain (if still busy), so
 		// the GPU will wait for the image available semaphore to be signaled when we start writing to the color attachment.
-		VkSemaphore wait_semaphores[] = { mImageAvailableSemaphores[current_frame] };
+		VkSemaphore swap_image_semaphore[] = { mImageAvailableSemaphores[current_frame] };
 		VkPipelineStageFlags wait_stages[] = { VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT };
 		submit_info.waitSemaphoreCount = 1;
-		submit_info.pWaitSemaphores = wait_semaphores;
+		submit_info.pWaitSemaphores = swap_image_semaphore;
 		submit_info.pWaitDstStageMask = wait_stages;
 		submit_info.commandBufferCount = 1;
 		submit_info.pCommandBuffers = &mCommandBuffers[current_frame];
 
 		// When the command buffer has completed execution, the render finished semaphore is signaled. This semaphore
 		// is used by the GPU presentation engine to wait before presenting the finished image to screen.
-		VkSemaphore signalSemaphores[] = { mRenderFinishedSemaphores[current_frame] };
-
+		VkSemaphore render_semaphore[] = { mRenderFinishedSemaphores[mSwapIndex] };
 		submit_info.signalSemaphoreCount = 1;
-		submit_info.pSignalSemaphores = signalSemaphores;
-		
+		submit_info.pSignalSemaphores = render_semaphore;
+
+		// Submit the queue for rendering
 		VkResult result = vkQueueSubmit(mRenderService->getQueue(), 1, &submit_info, VK_NULL_HANDLE);
 		assert(result == VK_SUCCESS);
 
 		// Set the rendering bit of queue submit ops of the current frame
 		mRenderService->mFramesInFlight[current_frame].mQueueSubmitOps |= RenderService::EQueueSubmitOp::Rendering;
 
-		// Create present information
+		// Create presentation information -> wait for the render finished semaphore to be signalled before presenting
+		VkSwapchainKHR swap_chains[] = { mSwapchain };
 		VkPresentInfoKHR present_info = {};
 		present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
 		present_info.waitSemaphoreCount = 1;
-		present_info.pWaitSemaphores = signalSemaphores;
-
-		// Add swap chain
-		VkSwapchainKHR swap_chains[] = { mSwapchain };
-		present_info.swapchainCount = 1; // Await only the render finished semaphore
+		present_info.pWaitSemaphores = render_semaphore;
+		present_info.swapchainCount = 1;						// Await only the render finished semaphore
 		present_info.pSwapchains = swap_chains;
-		present_info.pImageIndices = &mCurrentImageIndex;
+		present_info.pImageIndices = &mSwapIndex;
 
 		// According to the spec, vkQueuePresentKHR can return VK_ERROR_OUT_OF_DATE_KHR when the framebuffer no longer matches the swapchain.
 		// In our case this should only happen due to window size changes, which is handled in makeCurrent. So, we don't attempt to handle it here.
@@ -903,7 +902,7 @@ namespace nap
 		if (!createCommandBuffers(mDevice, mRenderService->getCommandPool(), mCommandBuffers, mRenderService->getMaxFramesInFlight(), errorState))
 			return false;
 
-		mImagesInFlight.resize(chain_images.size(), -1);
+		mFramesInFlight.resize(chain_images.size(), -1);
 		return true;
 	}
 
@@ -923,7 +922,7 @@ namespace nap
 		}
 
 		// Reset image tracking
-		mImagesInFlight.clear();
+		mFramesInFlight.clear();
 
 		// Destroy render pass if present
 		if (mRenderPass != VK_NULL_HANDLE)
@@ -963,7 +962,7 @@ namespace nap
 		VkRenderPassBeginInfo render_pass_info = {};
 		render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
 		render_pass_info.renderPass = mRenderPass;
-		render_pass_info.framebuffer = mSwapChainFramebuffers[mCurrentImageIndex];
+		render_pass_info.framebuffer = mSwapChainFramebuffers[mSwapIndex];
 		render_pass_info.renderArea.offset = { 0, 0 };
 		render_pass_info.renderArea.extent = mSwapchainExtent;
 

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -314,12 +314,11 @@ namespace nap
 		std::vector<VkCommandBuffer>	mCommandBuffers;
 		std::vector<VkSemaphore>		mImageAvailableSemaphores;
 		std::vector<VkSemaphore>		mRenderFinishedSemaphores;
-		std::vector<int>				mFramesInFlight;
 		VkPresentModeKHR				mPresentationMode = VK_PRESENT_MODE_MAILBOX_KHR;
 		ImageData						mDepthImage;
 		ImageData						mColorImage;
 		bool							mSampleShadingEnabled = false;
-		uint32							mSwapIndex = 0;
+		uint32							mPresentIndex = 0;
 		uint32							mSwapChainImageCount = 0;
 		bool							mRecreateSwapchain = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -312,13 +312,13 @@ namespace nap
 		std::vector<VkImageView>		mSwapChainImageViews;
 		std::vector<VkFramebuffer>		mSwapChainFramebuffers;
 		std::vector<VkCommandBuffer>	mCommandBuffers;
-		std::vector<VkSemaphore>		mImageAvailableSemaphores;
-		std::vector<VkSemaphore>		mRenderFinishedSemaphores;
+		std::vector<VkSemaphore>		mAcquireSemaphores;
+		std::vector<VkSemaphore>		mSubmitSemaphores;
 		VkPresentModeKHR				mPresentationMode = VK_PRESENT_MODE_MAILBOX_KHR;
 		ImageData						mDepthImage;
 		ImageData						mColorImage;
 		bool							mSampleShadingEnabled = false;
-		uint32							mPresentIndex = 0;
+		uint32							mImageIndex = 0;
 		uint32							mSwapChainImageCount = 0;
 		bool							mRecreateSwapchain = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;

--- a/system_modules/naprender/src/renderwindow.h
+++ b/system_modules/naprender/src/renderwindow.h
@@ -314,12 +314,12 @@ namespace nap
 		std::vector<VkCommandBuffer>	mCommandBuffers;
 		std::vector<VkSemaphore>		mImageAvailableSemaphores;
 		std::vector<VkSemaphore>		mRenderFinishedSemaphores;
-		std::vector<int>				mImagesInFlight;
+		std::vector<int>				mFramesInFlight;
 		VkPresentModeKHR				mPresentationMode = VK_PRESENT_MODE_MAILBOX_KHR;
 		ImageData						mDepthImage;
 		ImageData						mColorImage;
 		bool							mSampleShadingEnabled = false;
-		uint32							mCurrentImageIndex = 0;
+		uint32							mSwapIndex = 0;
 		uint32							mSwapChainImageCount = 0;
 		bool							mRecreateSwapchain = false;
 		VkSurfaceCapabilitiesKHR		mSurfaceCapabilities;


### PR DESCRIPTION
After updating the Vulkan SDK to 1.4.313 the validation layer reported the following issue (AMD Radeon 9070XT, Windows 11):

```
[error] vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0xbe00000000be) is being signaled by VkQueue 0x25b807309b0, but it may still be in use by VkSwapchainKHR 0xae00000000ae.
Here are the most recently acquired image indices: [0], 1, 2.
(brackets mark the last use of VkSemaphore 0xbe00000000be in a presentation operation)
Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0xbe00000000be may still be in use and cannot be safely reused with image index 2.
Vulkan insight: One solution is to assign each image its own semaphore. Here are some common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: Each binary semaphore element of the pSignalSemaphores member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device (https://vulkan.lunarg.com/doc/view/1.4.313.2/windows/antora/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit-pSignalSemaphores-00067)
```

As adviced, I introduced a 'render' semaphore for every available swapchain image and separated the image and render synchronization primitives. This means there are now 2 image semaphores (1 for each frame), and '3' render finished semaphores (variable depending on number of additional swap-chain images). The image semaphores are used to signal the renderer when the presentation surface is available for drawing, the rendering semaphores are used to tell the presentation engine when the surface is available to be presented after rendering finishes. 

I also removed a fence, because it wasn't required any longer (?) The render engine already waits after queue submission for the image available semaphore to be triggered before rendering, removing the need to explicitly synchronize the frame to the current swap chain image index.