### PR TITLE
Upgrade napaudio with internal SafePtr validity checks

### DIFF
--- a/system_modules/napaudio/src/audio/component/levelmetercomponent.cpp
+++ b/system_modules/napaudio/src/audio/component/levelmetercomponent.cpp
@@ -49,6 +49,7 @@ namespace nap
 			
 			mMeter = nodeManager.makeSafe<LevelMeterNode>(nodeManager, mResource->mAnalysisWindowSize);
 			mMeter->setType(mResource->mMeterType);
+			nodeManager.registerRootProcess(mMeter.get());
 			
 			if (mResource->mFilterInput)
 			{

--- a/system_modules/napaudio/src/audio/component/outputcomponent.cpp
+++ b/system_modules/napaudio/src/audio/component/outputcomponent.cpp
@@ -60,6 +60,7 @@ namespace nap
 					// If the channel is out of bounds we create a PullNode instead of an OutputNode in order to process the connected DSP branch.
 					auto pullNode = nodeManager.makeSafe<PullNode>(nodeManager);
 					pullNode->audioInput.connect(*mInput->getOutputForChannel(mChannelRouting[channel]));
+					nodeManager.registerRootProcess(pullNode.get());
 					mOutputs.emplace_back(std::move(pullNode));
 					continue;
 				}
@@ -67,6 +68,7 @@ namespace nap
 					auto outputNode = nodeManager.makeSafe<OutputNode>(nodeManager);
 					outputNode->setOutputChannel(channel);
 					outputNode->audioInput.connect(*mInput->getOutputForChannel(mChannelRouting[channel]));
+					nodeManager.registerRootProcess(outputNode.get());
 					mOutputs.emplace_back(std::move(outputNode));
 				}
 			}

--- a/system_modules/napaudio/src/audio/core/multichannel.cpp
+++ b/system_modules/napaudio/src/audio/core/multichannel.cpp
@@ -24,14 +24,28 @@ namespace nap
 			if (channel < getInputChannelCount())
 				connect(channel, pin);
 		}
-		
-		
+
+
+		void IMultiChannelInput::tryDisconnect(unsigned int channel, OutputPin& pin)
+		{
+			if (channel < getInputChannelCount())
+				disconnect(channel, pin);
+		}
+
+
 		void IMultiChannelInput::connect(IMultiChannelOutput& inputObject)
 		{
 			for (auto channel = 0; channel < getInputChannelCount(); ++channel)
 				connect(channel, *inputObject.getOutputForChannel(channel % inputObject.getChannelCount()));
 		}
-		
+
+
+		void IMultiChannelInput::disconnect(IMultiChannelOutput& inputObject)
+		{
+			for (auto channel = 0; channel < getInputChannelCount(); ++channel)
+				disconnect(channel, *inputObject.getOutputForChannel(channel % inputObject.getChannelCount()));
+		}
+
 	}
 	
 }

--- a/system_modules/napaudio/src/audio/core/multichannel.h
+++ b/system_modules/napaudio/src/audio/core/multichannel.h
@@ -58,17 +58,24 @@ namespace nap
 			virtual ~IMultiChannelInput() = default;
 
 			/**
-			 * This method has to be overwritten to connect an output pin from another object to this object's input.
-			 * @param channel index of the channel to connect to
-			 * @param pin pin that will be connected to this object
-			 */
-			virtual void connect(unsigned int channel, OutputPin& pin) { }
-
-			/**
 			 * This method has to be overwritten by descendants.
 			 * @return the number of input channels of audio this object receives.
 			 */
 			virtual int getInputChannelCount() const { return 0; }
+
+			/**
+			 * Needs to be overwritten to connect pin to the input(s) for the given channel.
+			 * @param channel index of the channel to connect to
+			 * @param pin pin that will be connected to this object
+			 */
+			virtual void connect(unsigned int channel, OutputPin& pin) { assert(false); }
+
+			/**
+			 * Needs to be overwritten to disconnect pin from the input(s) for the given channel
+			 * @param channel index of the channel to disconnect from
+			 * @param pin pin that will be disconnected from this object
+			 */
+			virtual void disconnect(unsigned int channel, OutputPin& pin) { assert(false); }
 
 			/**
 			 * This method calls connect() but first checks wether the given channel is not out of bounds.
@@ -78,11 +85,26 @@ namespace nap
 			void tryConnect(unsigned int channel, OutputPin& pin);
 
 			/**
+			 * This method calls disconnect() but first checks wether the given channel is not out of bounds.
+			 * @param channel channel index to connect to
+			 * @param pin pin that will be connected to this object
+			 */
+			void tryDisconnect(unsigned int channel, OutputPin& pin);
+
+			/**
 			 * Convenience method that connects the outputs of inputObject to the inputs of this object.
 			 * If this object has more input channels than inputObject has output channels they will be repeated.
 			 * @param inputObject object to be connected to this object
 			 */
 			void connect(IMultiChannelOutput& inputObject);
+
+			/**
+			 * Convenience method that disconnects the outputs of inputObject from the inputs of this object.
+			 * If this object has more input channels than inputObject has output channels they will be repeated.
+			 * @param inputObject object to be connected to this object
+			 */
+			void disconnect(IMultiChannelOutput& inputObject);
+
 		};
 	}
 }

--- a/system_modules/napaudio/src/audio/core/process.h
+++ b/system_modules/napaudio/src/audio/core/process.h
@@ -88,6 +88,11 @@ namespace nap
 			 */
 			DiscreteTimeValue getSampleTime() const;
 
+			/**
+			 * Returns SafePtr to this Process.
+			 */
+			SafePtr<Process> getSafe() { return mSelf; }
+
 		protected:
 			/**
 			 * Called whenever the sample rate that the node system runs on changes.
@@ -131,6 +136,8 @@ namespace nap
 
 			// Set to true when the node has made itself known with the node manager. This registration is deferred to the audio thread so it has to be tracked by this boolean.
 			std::atomic<bool> mRegisteredWithNodeManager = { false };
+
+			SafePtr<Process> mSelf = nullptr; // This is a safe pointer to self that is set by NodeManager::makeSafe(). It can be used to check whether the Process is not deleted or being deleted.
 		};
 
 
@@ -179,23 +186,12 @@ namespace nap
 			void removeChild(Process& child);
 
 			/**
-			 * Directly triggers parallel processing of all child processes.
-			 * Child processes will be processed simultaneously on different threads in the ThreadPool.
-			 */
-			void processParallel();
-
-			/**
-			 * Directly triggers sequential (or serial) processing of all child processes.
-			 */
-			void processSequential();
-
-			/**
 			 * Process method chooses between parallel or sequential processing of the children according to mode specified by the setMode() method.
 			 */
 			void process() override;
 
 			/**
-			 * Specifies wether the child processes will be processed in parallel or sequential mode.
+			 * Specifies whether the child processes will be processed in parallel or sequential mode.
 			 * In case of parallel processing the child processes are triggered simultaneously on different threads in the ThreadPool.
 			 * In case of sequential processing they are processed one by one on the caller thread.
 			 */
@@ -207,9 +203,20 @@ namespace nap
 			Mode getMode() const { return mMode.load(); }
 
 		private:
+			/**
+			 * Directly triggers parallel processing of all child processes.
+			 * Child processes will be processed simultaneously on different threads in the ThreadPool.
+			 */
+			void processParallel();
+
+			/**
+			 * Directly triggers sequential (or serial) processing of all child processes.
+			 */
+			void processSequential();
+
 			ThreadPool& mThreadPool;
 			AsyncObserver& mAsyncObserver;
-			std::vector<Process*> mChildren;
+			std::vector<SafePtr<Process>> mChildren;
 			std::atomic<Mode> mMode = {Mode::Sequential};
 		};
 

--- a/system_modules/napaudio/src/audio/node/filternode.cpp
+++ b/system_modules/napaudio/src/audio/node/filternode.cpp
@@ -126,8 +126,20 @@ namespace nap
 			calcCoeffs();
 			mIsDirty.set();
 		}
-		
-		
+
+		void FilterNode::set(EMode mode, ControllerValue frequency, ControllerValue resonance, ControllerValue band,
+			ControllerValue gain)
+		{
+			mMode = mode;
+			mFrequency = frequency;
+			mResonance = resonance;
+			mBand = band;
+			mGain = gain;
+			calcCoeffs();
+			mIsDirty.set();
+		}
+
+
 		void FilterNode::update()
 		{
 			a0.setValue(a0Dest);

--- a/system_modules/napaudio/src/audio/node/filternode.h
+++ b/system_modules/napaudio/src/audio/node/filternode.h
@@ -87,6 +87,16 @@ namespace nap
 			void setGain(ControllerValue gain);
 
 			/**
+			 * Sets all the filter parameters at once, recalculating the coefficients only once.
+			 * @param mode lowpass, highpass, bandpass, lowpass with resonance peak or highpass with resonance peak.
+			 * @param frequency The frequency parameter of the filter in Hz.
+			 * @param resonance Sets the resonance peak of the filter. 0 means no resonance, 30 means self-oscillation.
+			 * @param band Sets the bandwith for bandpass filtering in Hz.
+			 * @param gain Sets the gaining factor of the filter's output.
+			 */
+			void set(EMode mode, ControllerValue frequency, ControllerValue resonance, ControllerValue band, ControllerValue gain);
+
+			/**
 			 * @return the mode of the filter.
 			 */
 			EMode getMode() const { return mMode; }
@@ -117,7 +127,7 @@ namespace nap
 
 			std::atomic<EMode> mMode = {EMode::LowPass};
 			std::atomic<ControllerValue> mFrequency = {440.f};
-			std::atomic<ControllerValue> mResonance = {0.f};
+			std::atomic<ControllerValue> mResonance = {1.f};
 			std::atomic<ControllerValue> mBand = {100.f};
 			std::atomic<ControllerValue> mGain = {1.f};
 			DirtyFlag mIsDirty;

--- a/system_modules/napaudio/src/audio/node/levelmeternode.h
+++ b/system_modules/napaudio/src/audio/node/levelmeternode.h
@@ -37,13 +37,14 @@ namespace nap
 			/**
 			 * @param nodeManager: the node manager
 			 * @param analysisWindowSize: the time window in milliseconds that will be used to generate one single output value. Also the period that corresponds to the analysis frequency.
-			 * @param rootProcess: indicates that the node is registered as root process with the AudioNodeManager and is processed automatically.
 			 */
-			LevelMeterNode(NodeManager& nodeManager, TimeValue analysisWindowSize = 10, bool rootProcess = true);
+			LevelMeterNode(NodeManager& nodeManager, TimeValue analysisWindowSize = 10);
 
 			virtual ~LevelMeterNode();
 
 			InputPin input = {this}; /**< The input for the audio signal that will be analyzed. */
+
+			OutputPin output = { this }; /**< If this output is connected the LevelMeterNode will output its input. */
 
 			/**
 			 * @return: The current level of the analyzed signal.

--- a/system_modules/napaudio/src/audio/node/outputnode.cpp
+++ b/system_modules/napaudio/src/audio/node/outputnode.cpp
@@ -17,18 +17,13 @@ namespace nap
 	namespace audio
 	{
 		
-		OutputNode::OutputNode(NodeManager& nodeManager, bool rootProcess) : Node(nodeManager),
-		                                                                     mRootProcess(rootProcess)
+		OutputNode::OutputNode(NodeManager& nodeManager) : Node(nodeManager)
 		{
-			if (rootProcess)
-				getNodeManager().registerRootProcess(*this);
 		}
 		
 		
 		OutputNode::~OutputNode()
 		{
-			if (mRootProcess && isRegisteredWithNodeManager())
-				getNodeManager().unregisterRootProcess(*this);
 		}
 		
 		

--- a/system_modules/napaudio/src/audio/node/outputnode.h
+++ b/system_modules/napaudio/src/audio/node/outputnode.h
@@ -27,9 +27,8 @@ namespace nap
 		public:
 			/**
 			 * @param nodeManager The node manager
-			 * @param rootProcess true if the node is registered as root process and being processed from the moment of creation. This can cause glitches if the node tree and it's parameters are still being build.
 			 */
-			OutputNode(NodeManager& nodeManager, bool rootProcess = true);
+			OutputNode(NodeManager& nodeManager);
 
 			~OutputNode() override final;
 
@@ -52,10 +51,7 @@ namespace nap
 		private:
 			void process() override;
 
-			std::atomic<int> mOutputChannel = {
-					0}; // The audio channel that this node's input will be played on by the node manager.
-
-			bool mRootProcess = false;
+			std::atomic<int> mOutputChannel = { 0 }; // The audio channel that this node's input will be played on by the node manager.
 		};
 
 

--- a/system_modules/napaudio/src/audio/node/pullnode.cpp
+++ b/system_modules/napaudio/src/audio/node/pullnode.cpp
@@ -14,17 +14,13 @@ namespace nap
 	namespace audio
 	{
 		
-		PullNode::PullNode(NodeManager& nodeManager, bool rootProcess) : Node(nodeManager), mRootProcess(rootProcess)
+		PullNode::PullNode(NodeManager& nodeManager) : Node(nodeManager)
 		{
-			if (rootProcess)
-				getNodeManager().registerRootProcess(*this);
 		}
 		
 		
 		PullNode::~PullNode()
 		{
-			if (mRootProcess)
-				getNodeManager().unregisterRootProcess(*this);
 		}
 		
 		

--- a/system_modules/napaudio/src/audio/node/pullnode.h
+++ b/system_modules/napaudio/src/audio/node/pullnode.h
@@ -31,9 +31,8 @@ namespace nap
 		public:
 			/**
 			 * @param nodeManager: The node manager this node runs on
-			 * @param rootProcess: true if the node registered as root process and processed from creation.
 			 */
-			PullNode(NodeManager& nodeManager, bool rootProcess = true);
+			PullNode(NodeManager& nodeManager);
 			
 			~PullNode() override final;
 			
@@ -44,8 +43,6 @@ namespace nap
 		
 		private:
 			void process() override;
-			
-			bool mRootProcess = false;
 		};
 		
 		

--- a/system_modules/napaudio/src/audio/utility/audiotypes.h
+++ b/system_modules/napaudio/src/audio/utility/audiotypes.h
@@ -10,6 +10,7 @@
 // nap includes
 #include <utility/dllexport.h>
 #include <nap/numeric.h>
+#include <rtti/typeinfo.h>
 
 namespace nap
 {
@@ -39,6 +40,7 @@ namespace nap
 		 */
 		class NAPAPI MultiSampleBuffer
 		{
+			RTTI_ENABLE()
 		public:
 			MultiSampleBuffer() = default;
 			

--- a/system_modules/napaudio/src/audio/utility/linearsmoothedvalue.h
+++ b/system_modules/napaudio/src/audio/utility/linearsmoothedvalue.h
@@ -7,6 +7,8 @@
 // Nap includes
 #include <nap/signalslot.h>
 
+#include <atomic>
+
 namespace nap
 {
 	namespace audio
@@ -98,7 +100,7 @@ namespace nap
 			T mValue; // Value that is being controlled by this object.
 			T mIncrement; // Increment value per step of the current ramp when mode is linear.
 			T mDestination = 0; // Destination value of the current ramp.
-			std::atomic<int> mStepCount = 0; // Number of steps in the ramp.
+			std::atomic<int> mStepCount = { 0 }; // Number of steps in the ramp.
 			int mStepCounter = 0; // Current step index, 0 means at destination
 		};
 		

--- a/system_modules/napaudio/src/audio/utility/safeptr.h
+++ b/system_modules/napaudio/src/audio/utility/safeptr.h
@@ -467,19 +467,26 @@ namespace nap
 
 			T* get() const
 			{
-				assert(isValid());
+				if (!isValid())
+					return nullptr;
 				return static_cast<T*>((*mOwnerData)->mObject.get());
 			}
 
 			T* get()
 			{
-				assert(isValid());
+				if (!isValid())
+					return nullptr;
 				return static_cast<T*>((*mOwnerData)->mObject.get());
 			}
 
 		private:
 			void* getOwnerData() const override
-			{ return *mOwnerData; }
+			{
+				if (mOwnerData != nullptr)
+					return *mOwnerData;
+				else
+					return nullptr;
+			}
 
 			void setOwnerData(void* ownerData) override
 			{

--- a/system_modules/napaudio/src/audio/utility/translator.h
+++ b/system_modules/napaudio/src/audio/utility/translator.h
@@ -12,6 +12,9 @@
 // Audio includes
 #include <audio/utility/audiofunctions.h>
 
+// Rtti include
+#include <rtti/typeinfo.h>
+
 
 namespace nap
 {
@@ -96,17 +99,17 @@ namespace nap
 		/**
 		 * A convenience translator for equal power lookups, owns a table so it does not need to be provided
 		 */
-		template<typename T>
-		class EqualPowerTranslator : public TableTranslator<T>
+		class EqualPowerTranslator : public TableTranslator<float>
 		{
+			RTTI_ENABLE()
 		public:
 			/**
 			 * constructor
 			 */
-			EqualPowerTranslator(unsigned int size) : TableTranslator<T>(size)
+			EqualPowerTranslator(unsigned int size) : TableTranslator<float>(size)
 			{
 				// fills the table using equal power function
-				TableTranslator<T>::fill([](T x) { return sin(x * math::PI_2); });
+				TableTranslator<float>::fill([](float x) { return sin(x * math::PI_2); });
 			}
 		
 		private:

--- a/system_modules/napfft/src/fftaudionodecomponent.cpp
+++ b/system_modules/napfft/src/fftaudionodecomponent.cpp
@@ -48,6 +48,12 @@ namespace nap
 	}
 
 
+	void FFTAudioNodeComponentInstance::onDestroy()
+	{
+		mAudioService->getNodeManager().unregisterRootProcess(mFFTNode.get());
+	}
+
+
 	void FFTAudioNodeComponentInstance::setInput(audio::AudioComponentBaseInstance& input)
 	{
 		auto inputPtr = &input;

--- a/system_modules/napfft/src/fftaudionodecomponent.cpp
+++ b/system_modules/napfft/src/fftaudionodecomponent.cpp
@@ -41,6 +41,7 @@ namespace nap
 		auto& node_manager = mAudioService->getNodeManager();
 		mFFTNode = node_manager.makeSafe<FFTNode>(node_manager);
 		mFFTNode->mInput.connect(*mInput->getOutputForChannel(mResource->mChannel));
+		mAudioService->getNodeManager().registerRootProcess(mFFTNode.get());
 		mFFTBuffer = &mFFTNode->getFFTBuffer();
 
 		return true;

--- a/system_modules/napfft/src/fftaudionodecomponent.h
+++ b/system_modules/napfft/src/fftaudionodecomponent.h
@@ -49,6 +49,7 @@ namespace nap
 			
 		// Initialize the component
 		virtual bool init(utility::ErrorState& errorState) override;
+		void onDestroy() override;
 			
 		/**
 		 * Connects a different audio component as input to be analyzed.

--- a/system_modules/napfft/src/fftnode.cpp
+++ b/system_modules/napfft/src/fftnode.cpp
@@ -21,13 +21,12 @@ namespace nap
 		assert(buffer_size >= 2);
 
 		mFFTBuffer = std::make_unique<FFTBuffer>(buffer_size, overlaps);
-		getNodeManager().registerRootProcess(*this);
 	}
 
 
 	FFTNode::~FFTNode()
 	{
-		getNodeManager().unregisterRootProcess(*this);
+		getNodeManager().unregisterRootProcess(getSafe());
 	}
 
 

--- a/system_modules/napsequenceaudio/src/sequenceplayeraudioclock.cpp
+++ b/system_modules/napsequenceaudio/src/sequenceplayeraudioclock.cpp
@@ -23,12 +23,22 @@ namespace nap
 
         auto& node_manager = audio_service->getNodeManager();
         mAudioClockProcess = node_manager.makeSafe<SequencePlayerAudioClockProcess>(node_manager);
+
+        // Register the clock to be processed directly by the NodeManager
+        node_manager.registerRootProcess(mAudioClockProcess.get());
+
         mAudioClockProcess->connectSlot(mUpdateSlot);
     }
 
 
     void SequencePlayerAudioClock::onDestroy()
     {
+        auto* audio_service = mService.getCore().getService<audio::AudioService>();
+        assert(audio_service!=nullptr);
+
+        // Unregister the clock from being processed directly by the NodeManager
+        audio_service->getNodeManager().unregisterRootProcess(mAudioClockProcess.get());
+        
         stop();
     }
 
@@ -43,13 +53,6 @@ namespace nap
             :audio::Process(nodeManager)
     {
         mTime = nodeManager.getSampleTime();
-        getNodeManager().registerRootProcess(*this);
-    }
-
-
-    SequencePlayerAudioClockProcess::~SequencePlayerAudioClockProcess() noexcept
-    {
-        getNodeManager().unregisterRootProcess(*this);
     }
 
 

--- a/system_modules/napsequenceaudio/src/sequenceplayeraudioclock.h
+++ b/system_modules/napsequenceaudio/src/sequenceplayeraudioclock.h
@@ -83,11 +83,6 @@ namespace nap
         SequencePlayerAudioClockProcess& operator=(const SequencePlayerAudioClockProcess&) = delete;
 
         /**
-         * Deconstructor, unregisters the process from node manager
-         */
-        virtual ~SequencePlayerAudioClockProcess();
-
-        /**
          * Connect update slot on audio-thread.
          * Thread-Safe
          * @param slot the update slot


### PR DESCRIPTION
Breaking change: Nodes (and all audio::Processes) cannot register themselves as root process from their ctors. This has to be done after a NodeManager::make_safe() call.

This branch is meant for testing the reported problem of the wrong nodes/pins being connected after a hotload. 